### PR TITLE
Don't allow a single interrupt to be recursive with itself.

### DIFF
--- a/Marlin/src/HAL/NATIVE_SIM/sim/execution_control.h
+++ b/Marlin/src/HAL/NATIVE_SIM/sim/execution_control.h
@@ -86,11 +86,17 @@ struct KernelTimer {
     this->name = name;
   }
   void execute() {
-    isr_function();
+    if (!isr_active)
+    {
+      isr_active = true;
+      isr_function();
+      isr_active = false;
+    }
   }
 
   std::string name;
   bool active = false;
+  bool isr_active = false;
   uint64_t compare = 0, source_offset = 0, timer_frequency = 0;
   std::function<void()> isr_function;
 };


### PR DESCRIPTION
### Description

The simulated DELAY_CYCLES ends up calling the execution loop while waiting, which can cause recursive interrupts.

I've added a variable to the KernelTimer class to avoid entering the same ISR twice.

**Weaknesses to this approach**
1. Not thread safe. This is fine as long as ISRs aren't coming in asynchronously from multiple threads
   - I original implemented this in a thread-safe way using `std::atomic_bool`, but had a problem that I'll add in a comment. It wasn't atomic related, I just decided to throw this up for comments without restoring it.
2. Doesn't mimic real recursive interrupts
   - While delaying, a lower priority interrupt could run. For example, a temp interrupt while waiting for a stepper delay.

### Benefits

Does not crash with a divide by zero when homing!

### Configurations

These configs crash when starting the first homing move, without this change:
[Simulator_Reproduce.zip](https://github.com/p3p/Marlin/files/5434646/Simulator_Reproduce.zip)

### Related Issues

N/A
