### PR TITLE
Many SPI devices Support for the Simulator

### DIFF
--- a/Marlin/src/HAL/NATIVE_SIM/HAL.cpp
+++ b/Marlin/src/HAL/NATIVE_SIM/HAL.cpp
@@ -78,4 +78,13 @@ void HAL_pwm_init() {
 
 }
 
+// Maple Compatibility
+volatile uint32_t systick_uptime_millis = 0;
+systickCallback_t systick_user_callback;
+void systick_attach_callback(systickCallback_t cb) { systick_user_callback = cb; }
+void SYSTICK_IRQHandler() {
+  systick_uptime_millis++;
+  if (systick_user_callback) systick_user_callback();
+}
+
 #endif // __PLAT_NATIVE_SIM__

--- a/Marlin/src/HAL/NATIVE_SIM/HAL.h
+++ b/Marlin/src/HAL/NATIVE_SIM/HAL.h
@@ -111,3 +111,8 @@ inline uint8_t HAL_get_reset_source(void) { return RST_POWER_ON; }
 #ifndef strcmp_P
   #define strcmp_P(a, b) strcmp((a), (b))
 #endif
+
+// Maple Compatibility
+typedef void (*systickCallback_t)(void);
+void systick_attach_callback(systickCallback_t cb);
+extern volatile uint32_t systick_uptime_millis;

--- a/Marlin/src/HAL/NATIVE_SIM/HAL.h
+++ b/Marlin/src/HAL/NATIVE_SIM/HAL.h
@@ -107,11 +107,6 @@ inline uint8_t HAL_get_reset_source(void) { return RST_POWER_ON; }
 #define DELAY_CYCLES(x) kernel.delayCycles(x)
 #define SYSTEM_YIELD() kernel.yield()
 
-// Add strcmp_P if missing
-#ifndef strcmp_P
-  #define strcmp_P(a, b) strcmp((a), (b))
-#endif
-
 // Maple Compatibility
 typedef void (*systickCallback_t)(void);
 void systick_attach_callback(systickCallback_t cb);

--- a/Marlin/src/HAL/NATIVE_SIM/HAL_SPI.cpp
+++ b/Marlin/src/HAL/NATIVE_SIM/HAL_SPI.cpp
@@ -1,0 +1,100 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * Software SPI functions originally from Arduino Sd2Card Library
+ * Copyright (c) 2009 by William Greiman
+ */
+
+#ifdef __PLAT_NATIVE_SIM__
+
+#include "../../inc/MarlinConfig.h"
+
+// Software SPI
+
+static uint8_t SPI_speed = 0;
+uint8_t swSpiTransfer_mode_0(uint8_t b, const uint8_t spi_speed, const pin_t sck_pin, const pin_t miso_pin, const pin_t mosi_pin ) {
+  LOOP_L_N(i, 8) {
+    if (spi_speed == 0) {
+      WRITE_PIN(mosi_pin, !!(b & 0x80));
+      WRITE_PIN(sck_pin, HIGH);
+      b <<= 1;
+      if (miso_pin >= 0 && READ_PIN(miso_pin)) b |= 1;
+      WRITE_PIN(sck_pin, LOW);
+    }
+    else {
+      const uint8_t state = (b & 0x80) ? HIGH : LOW;
+      LOOP_L_N(j, spi_speed)
+        WRITE_PIN(mosi_pin, state);
+
+      LOOP_L_N(j, spi_speed + (miso_pin >= 0 ? 0 : 1))
+        WRITE_PIN(sck_pin, HIGH);
+
+      b <<= 1;
+      if (miso_pin >= 0 && READ_PIN(miso_pin)) b |= 1;
+
+      LOOP_L_N(j, spi_speed)
+        WRITE_PIN(sck_pin, LOW);
+    }
+  }
+
+  return b;
+}
+
+static uint8_t spiTransfer(uint8_t b) {
+  return swSpiTransfer_mode_0(b, SPI_speed, SCK_PIN, MISO_PIN, MOSI_PIN);
+}
+
+void spiBegin() {
+  OUT_WRITE(SS_PIN, HIGH);
+  SET_OUTPUT(SCK_PIN);
+  SET_INPUT(MISO_PIN);
+  SET_OUTPUT(MOSI_PIN);
+}
+
+void spiInit(uint8_t spiRate) {
+  // SPI_speed = swSpiInit(spiRate, SCK_PIN, MOSI_PIN);
+  WRITE(MOSI_PIN, HIGH);
+  WRITE(SCK_PIN, LOW);
+}
+
+uint8_t spiRec() { return spiTransfer(0xFF); }
+
+void spiRead(uint8_t*buf, uint16_t nbyte) {
+  for (int i = 0; i < nbyte; i++)
+    buf[i] = spiTransfer(0xFF);
+}
+
+void spiSend(uint8_t b) { (void)spiTransfer(b); }
+
+void spiSend(const uint8_t* buf, size_t nbyte) {
+  for (uint16_t i = 0; i < nbyte; i++)
+    (void)spiTransfer(buf[i]);
+}
+
+void spiSendBlock(uint8_t token, const uint8_t* buf) {
+  (void)spiTransfer(token);
+  for (uint16_t i = 0; i < 512; i++)
+    (void)spiTransfer(buf[i]);
+}
+
+#endif // __PLAT_NATIVE_SIM__

--- a/Marlin/src/HAL/NATIVE_SIM/MarlinSPI.h
+++ b/Marlin/src/HAL/NATIVE_SIM/MarlinSPI.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ *
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (c) 2016 Bob Cousins bobcousins42@googlemail.com
+ * Copyright (c) 2015-2016 Nico Tonnhofer wurstnase.reprap@gmail.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include <SPI.h>
+
+using MarlinSPI = SPIClass;

--- a/Marlin/src/HAL/NATIVE_SIM/inc/Conditionals_adv.h
+++ b/Marlin/src/HAL/NATIVE_SIM/inc/Conditionals_adv.h
@@ -20,3 +20,12 @@
  *
  */
 #pragma once
+
+// Add strcmp_P if missing
+#ifndef strcmp_P
+  #define strcmp_P(a, b) strcmp((a), (b))
+#endif
+
+#ifndef strcat_P
+  #define strcat_P(dest, src) strcat((dest), (src))
+#endif

--- a/Marlin/src/HAL/NATIVE_SIM/include/SPI.h
+++ b/Marlin/src/HAL/NATIVE_SIM/include/SPI.h
@@ -1,0 +1,179 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "../../shared/HAL_SPI.h"
+
+#include <stdint.h>
+
+//#define MSBFIRST 1
+
+#define SPI_MODE0 0
+#define SPI_MODE1 1
+#define SPI_MODE2 2
+#define SPI_MODE3 3
+
+#define DATA_SIZE_8BIT  1
+#define DATA_SIZE_16BIT 2
+
+#define SPI_CLOCK_DIV2   0
+#define SPI_CLOCK_DIV4   1
+#define SPI_CLOCK_DIV8   2
+#define SPI_CLOCK_DIV16  3
+#define SPI_CLOCK_DIV32  4
+#define SPI_CLOCK_DIV64  5
+#define SPI_CLOCK_DIV128 6
+
+#ifndef SPI_CLOCK_MAX
+  #define SPI_CLOCK_MAX SPI_CLOCK_DIV2
+#endif
+
+#define BOARD_NR_SPI 1
+
+#define BOARD_SPI1_SCK_PIN      SCK_PIN
+#define BOARD_SPI1_MISO_PIN     MISO_PIN
+#define BOARD_SPI1_MOSI_PIN     MOSI_PIN
+
+//#define BOARD_SPI2_SCK_PIN      P0_07
+//#define BOARD_SPI2_MISO_PIN     P0_08
+//#define BOARD_SPI2_MOSI_PIN     P0_09
+
+class SPISettings {
+public:
+  SPISettings(uint32_t spiRate, int inBitOrder, int inDataMode) {
+    init_AlwaysInline(spiRate2Clock(spiRate), inBitOrder, inDataMode, DATA_SIZE_8BIT);
+  }
+  SPISettings(uint32_t inClock, uint8_t inBitOrder, uint8_t inDataMode, uint32_t inDataSize) {
+    if (__builtin_constant_p(inClock))
+      init_AlwaysInline(inClock, inBitOrder, inDataMode, inDataSize);
+    else
+      init_MightInline(inClock, inBitOrder, inDataMode, inDataSize);
+  }
+  SPISettings() {
+    init_AlwaysInline(4000000, MSBFIRST, SPI_MODE0, DATA_SIZE_8BIT);
+  }
+
+  //uint32_t spiRate() const { return spi_speed; }
+
+  static inline uint32_t spiRate2Clock(uint32_t spiRate) {
+    uint32_t Marlin_speed[7];
+    Marlin_speed[0] = 8333333;
+    Marlin_speed[1] = 4166667;
+    Marlin_speed[2] = 2083333;
+    Marlin_speed[3] = 1000000;
+    Marlin_speed[4] =  500000;
+    Marlin_speed[5] =  250000;
+    Marlin_speed[6] =  125000;
+    return Marlin_speed[spiRate > 6 ? 6 : spiRate];
+  }
+
+private:
+  void init_MightInline(uint32_t inClock, uint8_t inBitOrder, uint8_t inDataMode, uint32_t inDataSize) {
+    init_AlwaysInline(inClock, inBitOrder, inDataMode, inDataSize);
+  }
+  void init_AlwaysInline(uint32_t inClock, uint8_t inBitOrder, uint8_t inDataMode, uint32_t inDataSize) __attribute__((__always_inline__)) {
+    clock    = inClock;
+    bitOrder = inBitOrder;
+    dataMode = inDataMode;
+    dataSize = inDataSize;
+  }
+
+  //uint32_t spi_speed;
+  uint32_t clock;
+  uint32_t dataSize;
+  //uint32_t clockDivider;
+  uint8_t bitOrder;
+  uint8_t dataMode;
+  // LPC_SSP_TypeDef *spi_d;
+
+  friend class SPIClass;
+};
+
+/**
+ * @brief Wirish SPI interface.
+ *
+ * This is the same interface is available across HAL
+ *
+ * This implementation uses software slave management, so the caller
+ * is responsible for controlling the slave select line.
+ */
+class SPIClass {
+public:
+  /**
+   * @param spiPortNumber Number of the SPI port to manage.
+   */
+  SPIClass(uint8_t spiPortNumber);
+
+  /**
+  * Init using pins
+  */
+  SPIClass(int8_t mosi, int8_t miso, int8_t sclk, int8_t ssel=-1) : SPIClass(1) {}
+
+  /**
+   * Select and configure the current selected SPI device to use
+   */
+  void begin();
+
+  /**
+   * Disable the current SPI device
+   */
+  void end();
+
+  void beginTransaction(const SPISettings&);
+  void endTransaction();
+
+  // Transfer using 1 "Data Size"
+  uint8_t transfer(uint16_t data);
+  // Transfer 2 bytes in 8 bit mode
+  uint16_t transfer16(uint16_t data);
+
+  void send(uint8_t data);
+
+  uint16_t read();
+  void read(uint8_t *buf, uint32_t len);
+
+  void dmaSend(void *buf, uint16_t length, bool minc = true);
+  uint8_t dmaTransfer(const void * transmitBuf, void * receiveBuf, uint16_t length);
+
+  /**
+   * @brief Sets the number of the SPI peripheral to be used by
+   *        this HardwareSPI instance.
+   *
+   * @param spi_num Number of the SPI port. 1-2 in low density devices
+   *     or 1-3 in high density devices.
+   */
+  void setModule(uint8_t device);
+
+  void setClock(uint32_t clock);
+  void setClockDivider(uint32_t clock) {}
+  void setBitOrder(uint8_t bitOrder);
+  void setDataMode(uint8_t dataMode);
+  void setDataSize(uint32_t ds);
+
+  inline uint32_t getDataSize() { return _currentSetting->dataSize; }
+
+private:
+  SPISettings _settings[BOARD_NR_SPI];
+  SPISettings *_currentSetting;
+};
+
+extern SPIClass SPI;

--- a/Marlin/src/HAL/NATIVE_SIM/sim/application.cpp
+++ b/Marlin/src/HAL/NATIVE_SIM/sim/application.cpp
@@ -11,7 +11,7 @@ Application::Application() {
   sim.vis.create();
 
   user_interface.addElement<SerialMonitor>("Serial Monitor");
-  user_interface.addElement<TextureWindow>("Controller Display", sim.display.texture_id, sim.display.width / sim.display.height, [this](UiWindow* window){ this->sim.display.ui_callback(window); });
+  user_interface.addElement<TextureWindow>("Controller Display", sim.display.texture_id, (float)sim.display.width / (float)sim.display.height, [this](UiWindow* window){ this->sim.display.ui_callback(window); });
   user_interface.addElement<StatusWindow>("Status", &clear_color, [this](UiWindow* window){ this->sim.vis.ui_info_callback(window); });
   user_interface.addElement<Viewport>("Viewport", [this](UiWindow* window){ this->sim.vis.ui_viewport_callback(window); });
   //user_interface.addElement<GraphWindow>("graphs", sim.display.texture_id, 128.0 / 64.0, std::bind(&Simulation::ui_callback, &sim, std::placeholders::_1));

--- a/Marlin/src/HAL/NATIVE_SIM/sim/application.cpp
+++ b/Marlin/src/HAL/NATIVE_SIM/sim/application.cpp
@@ -11,7 +11,7 @@ Application::Application() {
   sim.vis.create();
 
   user_interface.addElement<SerialMonitor>("Serial Monitor");
-  user_interface.addElement<TextureWindow>("Controller Display", sim.display.texture_id, 128.0 / 64.0, [this](UiWindow* window){ this->sim.display.ui_callback(window); });
+  user_interface.addElement<TextureWindow>("Controller Display", sim.display.texture_id, sim.display.width / sim.display.height, [this](UiWindow* window){ this->sim.display.ui_callback(window); });
   user_interface.addElement<StatusWindow>("Status", &clear_color, [this](UiWindow* window){ this->sim.vis.ui_info_callback(window); });
   user_interface.addElement<Viewport>("Viewport", [this](UiWindow* window){ this->sim.vis.ui_viewport_callback(window); });
   //user_interface.addElement<GraphWindow>("graphs", sim.display.texture_id, 128.0 / 64.0, std::bind(&Simulation::ui_callback, &sim, std::placeholders::_1));

--- a/Marlin/src/HAL/NATIVE_SIM/sim/application.h
+++ b/Marlin/src/HAL/NATIVE_SIM/sim/application.h
@@ -6,7 +6,15 @@
 #include "user_interface.h"
 
 #include "hardware/Heater.h"
-#include "hardware/ST7920Device.h"
+#if HAS_GRAPHICAL_TFT
+  #include "hardware/ST7796Device.h"
+  using DisplayDevice = ST7796Device;
+  #define DISPLAY_PARAM SCK_PIN, MISO_PIN, MOSI_PIN, TFT_CS_PIN, TOUCH_CS_PIN, TFT_DC_PIN, BEEPER_PIN, BTN_EN1, BTN_EN2, BTN_ENC, KILL_PIN
+#else
+  #include "hardware/ST7920Device.h"
+  using DisplayDevice = ST7920Device;
+  #define DISPLAY_PARAM LCD_PINS_D4, LCD_PINS_ENABLE, LCD_PINS_RS, BEEPER_PIN, BTN_EN1, BTN_EN2, BTN_ENC, KILL_PIN
+#endif
 #ifdef SDSUPPORT
   #include "hardware/SDCard.h"
 #endif
@@ -50,7 +58,7 @@ public:
                   #ifdef SDSUPPORT
                   , sd(SCK_PIN, MISO_PIN, MOSI_PIN, SDSS)
                   #endif
-                  , display(LCD_PINS_D4, LCD_PINS_ENABLE, LCD_PINS_RS, BEEPER_PIN, BTN_EN1, BTN_EN2, BTN_ENC, KILL_PIN) {}
+                  , display(DISPLAY_PARAM) {}
 
   void process_event(SDL_Event& e) {}
 
@@ -69,6 +77,7 @@ public:
   #ifdef SDSUPPORT
     SDCard sd;
   #endif
+  DisplayDevice display;
   Visualisation vis;
 };
 

--- a/Marlin/src/HAL/NATIVE_SIM/sim/application.h
+++ b/Marlin/src/HAL/NATIVE_SIM/sim/application.h
@@ -6,18 +6,6 @@
 #include "user_interface.h"
 
 #include "hardware/Heater.h"
-#if ANY(TFT_COLOR_UI, TFT_CLASSIC_UI, TFT_LVGL_UI)
-  #include "hardware/ST7796Device.h"
-  using DisplayDevice = ST7796Device;
-  #define DISPLAY_PARAM SCK_PIN, MISO_PIN, MOSI_PIN, TFT_CS_PIN, TOUCH_CS_PIN, TFT_DC_PIN, BEEPER_PIN, BTN_EN1, BTN_EN2, BTN_ENC, KILL_PIN
-#else
-  #include "hardware/ST7920Device.h"
-  using DisplayDevice = ST7920Device;
-  #define DISPLAY_PARAM LCD_PINS_D4, LCD_PINS_ENABLE, LCD_PINS_RS, BEEPER_PIN, BTN_EN1, BTN_EN2, BTN_ENC, KILL_PIN
-#endif
-#ifdef SDSUPPORT
-  #include "hardware/SDCard.h"
-#endif
 #include "hardware/print_bed.h"
 
 #include "visualisation.h"
@@ -49,12 +37,30 @@ struct GraphWindow : public UiWindow {
 };
 
 #include "src/inc/MarlinConfig.h"
+#if ANY(TFT_COLOR_UI, TFT_CLASSIC_UI, TFT_LVGL_UI)
+  #include "hardware/ST7796Device.h"
+  using DisplayDevice = ST7796Device;
+  #define DISPLAY_PARAM SCK_PIN, MISO_PIN, MOSI_PIN, TFT_CS_PIN, TOUCH_CS_PIN, TFT_DC_PIN, BEEPER_PIN, BTN_EN1, BTN_EN2, BTN_ENC, KILL_PIN
+#else
+  #include "hardware/ST7920Device.h"
+  using DisplayDevice = ST7920Device;
+  #define DISPLAY_PARAM LCD_PINS_D4, LCD_PINS_ENABLE, LCD_PINS_RS, BEEPER_PIN, BTN_EN1, BTN_EN2, BTN_ENC, KILL_PIN
+#endif
+#ifdef SDSUPPORT
+  #include "hardware/SDCard.h"
+#endif
+#if HAS_SPI_FLASH
+  #include "hardware/W25QxxDevice.h"
+#endif
 
 class Simulation {
 public:
 
   Simulation() :  hotend(HEATER_0_PIN, TEMP_0_PIN),
                   bed_heater(HEATER_BED_PIN, TEMP_BED_PIN)
+                  #if HAS_SPI_FLASH
+                  , spi_flash(SCK_PIN, MISO_PIN, MOSI_PIN, W25QXX_CS_PIN, SPI_FLASH_SIZE)
+                  #endif
                   #ifdef SDSUPPORT
                   , sd(SCK_PIN, MISO_PIN, MOSI_PIN, SDSS)
                   #endif
@@ -74,6 +80,9 @@ public:
 
   Heater hotend;
   Heater bed_heater;
+  #if HAS_SPI_FLASH
+    W25QxxDevice spi_flash;
+  #endif
   #ifdef SDSUPPORT
     SDCard sd;
   #endif

--- a/Marlin/src/HAL/NATIVE_SIM/sim/application.h
+++ b/Marlin/src/HAL/NATIVE_SIM/sim/application.h
@@ -7,6 +7,9 @@
 
 #include "hardware/Heater.h"
 #include "hardware/ST7920Device.h"
+#ifdef SDSUPPORT
+  #include "hardware/SDCard.h"
+#endif
 #include "hardware/print_bed.h"
 
 #include "visualisation.h"
@@ -43,8 +46,11 @@ class Simulation {
 public:
 
   Simulation() :  hotend(HEATER_0_PIN, TEMP_0_PIN),
-                  bed_heater(HEATER_BED_PIN, TEMP_BED_PIN),
-                  display(LCD_PINS_D4, LCD_PINS_ENABLE, LCD_PINS_RS, BEEPER_PIN, BTN_EN1, BTN_EN2, BTN_ENC, KILL_PIN) {}
+                  bed_heater(HEATER_BED_PIN, TEMP_BED_PIN)
+                  #ifdef SDSUPPORT
+                  , sd(SCK_PIN, MISO_PIN, MOSI_PIN, SDSS)
+                  #endif
+                  , display(LCD_PINS_D4, LCD_PINS_ENABLE, LCD_PINS_RS, BEEPER_PIN, BTN_EN1, BTN_EN2, BTN_ENC, KILL_PIN) {}
 
   void process_event(SDL_Event& e) {}
 
@@ -60,7 +66,9 @@ public:
 
   Heater hotend;
   Heater bed_heater;
-  ST7920Device display;
+  #ifdef SDSUPPORT
+    SDCard sd;
+  #endif
   Visualisation vis;
 };
 

--- a/Marlin/src/HAL/NATIVE_SIM/sim/application.h
+++ b/Marlin/src/HAL/NATIVE_SIM/sim/application.h
@@ -6,7 +6,7 @@
 #include "user_interface.h"
 
 #include "hardware/Heater.h"
-#if HAS_GRAPHICAL_TFT
+#if ANY(TFT_COLOR_UI, TFT_CLASSIC_UI, TFT_LVGL_UI)
   #include "hardware/ST7796Device.h"
   using DisplayDevice = ST7796Device;
   #define DISPLAY_PARAM SCK_PIN, MISO_PIN, MOSI_PIN, TFT_CS_PIN, TOUCH_CS_PIN, TFT_DC_PIN, BEEPER_PIN, BTN_EN1, BTN_EN2, BTN_ENC, KILL_PIN

--- a/Marlin/src/HAL/NATIVE_SIM/sim/execution_control.h
+++ b/Marlin/src/HAL/NATIVE_SIM/sim/execution_control.h
@@ -291,7 +291,7 @@ public:
     delayCycles(nanosToTicks(secs * ONE_BILLION));
   }
 
-  std::atomic<float> realtime_scale = 50.0;
+  std::atomic<float> realtime_scale = 1.0;
   std::atomic_uint64_t ticks{0};
   uint64_t realtime_nanos = 0;
   static constexpr uint32_t frequency = 100'000'000;

--- a/Marlin/src/HAL/NATIVE_SIM/sim/hardware/SDCard.cpp
+++ b/Marlin/src/HAL/NATIVE_SIM/sim/hardware/SDCard.cpp
@@ -2,8 +2,6 @@
 #include "SDCard.h"
 #include "../../../../sd/SdInfo.h"
 
-#define SD_SIMULATOR_FAT_IMAGE "/Users/victor/Development/Marlin/fs.img"
-
 void SDCard::onByteReceived(uint8_t _byte) {
   SPISlavePeripheral::onByteReceived(_byte);
 

--- a/Marlin/src/HAL/NATIVE_SIM/sim/hardware/SDCard.cpp
+++ b/Marlin/src/HAL/NATIVE_SIM/sim/hardware/SDCard.cpp
@@ -1,0 +1,80 @@
+
+#include "SDCard.h"
+#include "../../../../sd/SdInfo.h"
+
+#define SD_SIMULATOR_FAT_IMAGE "/Users/victor/Development/Marlin/fs.img"
+
+void SDCard::onByteReceived(uint8_t _byte) {
+  SPISlavePeripheral::onByteReceived(_byte);
+
+  // 1 byte (cmd) + 4 byte (arg) + 1 byte (crc)
+  // response: 0 success
+  //
+  if (currentCommand > -1) {
+    //data
+    if (++byteCount == 5) {
+      crc = _byte;
+      printf("CMD: %d, arg: %d, crc: %d, byteCount: %d\n", currentCommand, arg, crc, byteCount);
+      switch (currentCommand) {
+        case CMD0:
+          setResponse(R1_IDLE_STATE);
+          if (fp) fclose(fp);
+          fp = fopen(SD_SIMULATOR_FAT_IMAGE, "rb");
+          break;
+        case CMD8:
+          if (true/*_type == SD_CARD_TYPE_SD1*/) {
+            setResponse((R1_ILLEGAL_COMMAND | R1_IDLE_STATE));
+          }
+          else {
+            memset(buf, 0xAA, 4);
+            setResponse(buf, 4);
+          }
+          break;
+        case CMD55:
+          setResponse(R1_READY_STATE);
+          break;
+        case CMD58:
+          buf[0] = R1_READY_STATE;
+          memset(buf+1, 0xC0, 3);
+          setResponse(buf, 4);
+          break;
+        case ACMD41:
+          setResponse(R1_READY_STATE);
+          break;
+        case CMD17: //read block
+          buf[0] = R1_READY_STATE;
+          buf[1] = DATA_START_BLOCK;
+          if (true  /*_type != SD_CARD_TYPE_SDHC*/) {
+            arg >>= 9;
+          }
+          fseek(fp, 512 * arg, SEEK_SET);
+          fread(buf + 2, 512, 1, fp);
+          buf[512 + 2] = 0; //crc
+          setResponse(buf, 512 + 3);
+          break;
+        default:
+          break;
+      }
+      // currentCommand = -1;
+    }
+    else if (byteCount <= 4) {
+      arg <<= 8;
+      arg |= _byte;
+    }
+
+    return;
+  }
+  // else if (_byte == 0) {
+  //   setResponse(0xFF);
+  //   return;
+  // }
+
+  currentCommand = _byte - 0x40;
+}
+
+void SDCard::onResponseSent() {
+  SPISlavePeripheral::onResponseSent();
+  currentCommand = -1;
+  byteCount = 0;
+  arg = 0;
+}

--- a/Marlin/src/HAL/NATIVE_SIM/sim/hardware/SDCard.h
+++ b/Marlin/src/HAL/NATIVE_SIM/sim/hardware/SDCard.h
@@ -41,4 +41,8 @@ public:
   uint8_t crc = 0;
   uint8_t buf[1024];
   FILE *fp = nullptr;
+  uint16_t waitForBytes = 0;
+  uint8_t commandWaitingForData = -1;
+  uint32_t argWaitingForData = -1;
+  uint16_t bufferIndex = 0;
 };

--- a/Marlin/src/HAL/NATIVE_SIM/sim/hardware/SDCard.h
+++ b/Marlin/src/HAL/NATIVE_SIM/sim/hardware/SDCard.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "../user_interface.h"
+
+#include "SPISlavePeripheral.h"
+
+class SDCard: public SPISlavePeripheral {
+public:
+  SDCard(pin_type clk, pin_type mosi, pin_type miso, pin_type cs, pin_type sd_detect = -1) : SPISlavePeripheral(clk, mosi, miso, cs), sd_detect(sd_detect) {}
+  virtual ~SDCard() {};
+
+  pin_type sd_detect;
+
+  void update() {}
+  void ui_callback(UiWindow* window);
+
+  void onByteReceived(uint8_t _byte) override;
+  void onEndTransaction() override {
+    SPISlavePeripheral::onEndTransaction();
+  };
+  void onResponseSent() override;
+
+  int8_t currentCommand = -1;
+  int32_t arg = 0;
+  int32_t byteCount = 0;
+  uint8_t crc = 0;
+  uint8_t buf[1024];
+  FILE *fp = nullptr;
+};

--- a/Marlin/src/HAL/NATIVE_SIM/sim/hardware/SDCard.h
+++ b/Marlin/src/HAL/NATIVE_SIM/sim/hardware/SDCard.h
@@ -4,6 +4,21 @@
 
 #include "SPISlavePeripheral.h"
 
+/**
+  * Instructions for create a FAT image:
+  * 1) Install mtools
+  * 2) Create the imagem file:
+  *    $ mformat -v "EMBEDDED FS" -t 1 -h 1 -s 10000 -S 2 -C -i fs.img -c 1 -r 1 -L 1
+  *    -s NUM is the number of sectors
+  * 3) Copy files to the image:
+  *    $ mcopy -i fs.img CFFFP_flow_calibrator.gcode ::/
+  * 4) Set the path for SD_SIMULATOR_FAT_IMAGE
+  */
+ //#define SD_SIMULATOR_FAT_IMAGE "/full/path/to/fs.img"
+ #ifndef SD_SIMULATOR_FAT_IMAGE
+   #error "You need set SD_SIMULATOR_FAT_IMAGE with a path for a FAT filesystem image."
+ #endif
+
 class SDCard: public SPISlavePeripheral {
 public:
   SDCard(pin_type clk, pin_type mosi, pin_type miso, pin_type cs, pin_type sd_detect = -1) : SPISlavePeripheral(clk, mosi, miso, cs), sd_detect(sd_detect) {}

--- a/Marlin/src/HAL/NATIVE_SIM/sim/hardware/SPISlavePeripheral.cpp
+++ b/Marlin/src/HAL/NATIVE_SIM/sim/hardware/SPISlavePeripheral.cpp
@@ -47,17 +47,18 @@ void SPISlavePeripheral::onByteReceived(uint8_t _byte) {
 
 void SPISlavePeripheral::onResponseSent() {
   // printf("SPISlavePeripheral::onResponseSent\n");
+  hasDataToSend = false;
 }
 
 void SPISlavePeripheral::onByteSent(uint8_t _byte) {
   // printf("SPISlavePeripheral::onByteSent: %d\n", _byte);
-  if (responseDataSize ==  0) {
-    onResponseSent();
-  }
-  else {
+  if (responseDataSize > 0) {
     outgoing_byte = *responseData;
     responseData++;
     responseDataSize--;
+  }
+  else if (hasDataToSend) {
+    onResponseSent();
   }
   outgoing_bit_count = 0;
 }
@@ -90,6 +91,7 @@ void SPISlavePeripheral::setResponse(uint8_t *_bytes, size_t count) {
     responseData++;
     responseDataSize--;
   }
+  hasDataToSend = true;
 }
 
 void SPISlavePeripheral::spiInterrupt(GpioEvent& ev) {

--- a/Marlin/src/HAL/NATIVE_SIM/sim/hardware/SPISlavePeripheral.cpp
+++ b/Marlin/src/HAL/NATIVE_SIM/sim/hardware/SPISlavePeripheral.cpp
@@ -63,7 +63,7 @@ void SPISlavePeripheral::onResponseSent() {
 }
 
 void SPISlavePeripheral::onRequestedDataReceived(uint8_t token, uint8_t* _data, size_t count) {
-  printf("SPISlavePeripheral::onRequestedDataReceived\n");
+  // printf("SPISlavePeripheral::onRequestedDataReceived\n");
 }
 
 void SPISlavePeripheral::onByteSent(uint8_t _byte) {

--- a/Marlin/src/HAL/NATIVE_SIM/sim/hardware/SPISlavePeripheral.cpp
+++ b/Marlin/src/HAL/NATIVE_SIM/sim/hardware/SPISlavePeripheral.cpp
@@ -105,13 +105,13 @@ void SPISlavePeripheral::spiInterrupt(GpioEvent& ev) {
     // When CPOL is 1, data must be read when clock FALL
     if ((ev.event == GpioEvent::RISE && CPOL == 0) || (ev.event == GpioEvent::FALL && CPOL == 1)) {
       const uint8_t currentBit = Gpio::pin_map[mosi_pin].value;
-      incomming_byte = (incomming_byte << 1) | currentBit;
+      incoming_byte = (incoming_byte << 1) | currentBit;
       onBitReceived(currentBit);
-      if (++incomming_bit_count == 8) {
-        onByteReceived(incomming_byte);
-        incomming_byte = 0;
-        incomming_bit_count = 0;
-        incomming_byte_count++;
+      if (++incoming_bit_count == 8) {
+        onByteReceived(incoming_byte);
+        incoming_byte = 0;
+        incoming_bit_count = 0;
+        incoming_byte_count++;
       }
     }
     // == WRITE ==

--- a/Marlin/src/HAL/NATIVE_SIM/sim/hardware/SPISlavePeripheral.cpp
+++ b/Marlin/src/HAL/NATIVE_SIM/sim/hardware/SPISlavePeripheral.cpp
@@ -1,0 +1,124 @@
+#include "SPISlavePeripheral.h"
+
+SPISlavePeripheral::SPISlavePeripheral(pin_type clk, pin_type miso, pin_type mosi, pin_type cs, uint8_t CPOL, uint8_t CPHA) : clk_pin(clk), miso_pin(miso), mosi_pin(mosi), cs_pin(cs), CPOL(CPOL), CPHA(CPHA) {
+  Gpio::attach(clk_pin, [this](GpioEvent& event){ this->spiInterrupt(event); });
+  Gpio::attach(cs_pin, [this](GpioEvent& event){ this->spiInterrupt(event); });
+}
+
+SPISlavePeripheral::~SPISlavePeripheral() {};
+
+void SPISlavePeripheral::onBeginTransaction() {
+  // printf("SPISlavePeripheral::onBeginTransaction\n");
+  outgoing_byte = 0;
+  outgoing_bit_count = 0;
+  if (CPHA == 0) {
+    //when CPHA is 0: data must be available on MISO when CS fall
+    transmitCurrentBit();
+  }
+}
+
+void SPISlavePeripheral::transmitCurrentBit() {
+  // MSB
+  const uint8_t b = (outgoing_byte >> (7 - outgoing_bit_count)) & 1;
+  Gpio::pin_map[miso_pin].value = b;
+  onBitSent(b);
+  if (++outgoing_bit_count == 8) {
+    onByteSent(outgoing_byte);
+  }
+}
+
+void SPISlavePeripheral::onEndTransaction() {
+  // printf("SPISlavePeripheral::onEndTransaction\n");
+}
+
+void SPISlavePeripheral::onBitReceived(uint8_t _bit) {
+  // printf("SPISlavePeripheral::onBitReceived: %d\n", _bit);
+}
+
+void SPISlavePeripheral::onBitSent(uint8_t _bit) {
+  // printf("SPISlavePeripheral::onBitSent: %d\n", _bit);
+}
+
+void SPISlavePeripheral::onByteReceived(uint8_t _byte) {
+  // printf("SPISlavePeripheral::onByteReceived: %d\n", _byte);
+}
+
+void SPISlavePeripheral::onResponseSent() {
+  // printf("SPISlavePeripheral::onResponseSent\n");
+}
+
+void SPISlavePeripheral::onByteSent(uint8_t _byte) {
+  // printf("SPISlavePeripheral::onByteSent: %d\n", _byte);
+  if (responseDataSize ==  0) {
+    onResponseSent();
+  }
+  else {
+    outgoing_byte = *responseData;
+    responseData++;
+    responseDataSize--;
+  }
+  outgoing_bit_count = 0;
+}
+
+void SPISlavePeripheral::setResponse(uint8_t _data) {
+  static uint8_t _response = 0;
+  _response = _data;
+  setResponse(&_response, 1);
+}
+
+void SPISlavePeripheral::setResponse16(uint16_t _data, bool msb) {
+  static uint16_t _response = 0;
+  if (msb) {
+    _response = ((_data << 8) & 0xFF00) | (_data >> 8);
+  }
+  else {
+    _response = _data;
+  }
+  setResponse((uint8_t*)&_response, 2);
+  // printf("setResponse: %d, %d\n", _data, _response);
+}
+
+void SPISlavePeripheral::setResponse(uint8_t *_bytes, size_t count) {
+  responseData = _bytes;
+  responseDataSize = count;
+  // if ready, set the next byte to send
+  if (outgoing_bit_count == 0) {
+    outgoing_bit_count = 0;
+    outgoing_byte = *responseData;
+    responseData++;
+    responseDataSize--;
+  }
+}
+
+void SPISlavePeripheral::spiInterrupt(GpioEvent& ev) {
+  if (ev.pin_id == cs_pin) {
+    if (ev.event == GpioEvent::FALL && Gpio::pin_map[cs_pin].value == 0) onBeginTransaction();
+    else if (ev.event == GpioEvent::RISE && Gpio::pin_map[cs_pin].value != 0) onEndTransaction();
+    return;
+  }
+
+  if (Gpio::pin_map[cs_pin].value != 0) return;
+
+  if (ev.pin_id == clk_pin) {
+    // == Read ==
+    // When CPOL is 0, data must be read when clock RISE
+    // When CPOL is 1, data must be read when clock FALL
+    if ((ev.event == GpioEvent::RISE && CPOL == 0) || (ev.event == GpioEvent::FALL && CPOL == 1)) {
+      const uint8_t currentBit = Gpio::pin_map[mosi_pin].value;
+      incomming_byte = (incomming_byte << 1) | currentBit;
+      onBitReceived(currentBit);
+      if (++incomming_bit_count == 8) {
+        onByteReceived(incomming_byte);
+        incomming_byte = 0;
+        incomming_bit_count = 0;
+        incomming_byte_count++;
+      }
+    }
+    // == WRITE ==
+    // When CPOL is 0, data must be avaliable when clock FALL
+    // When CPOL is 1, data must be avaliable when clock RISE
+    else if ((ev.event == GpioEvent::FALL && CPOL == 0) || (ev.event == GpioEvent::RISE && CPOL == 1)) {
+      transmitCurrentBit();
+    }
+  }
+}

--- a/Marlin/src/HAL/NATIVE_SIM/sim/hardware/SPISlavePeripheral.h
+++ b/Marlin/src/HAL/NATIVE_SIM/sim/hardware/SPISlavePeripheral.h
@@ -36,4 +36,5 @@ private:
   uint8_t outgoing_bit_count = 0;
   uint8_t *responseData = nullptr;
   size_t responseDataSize = 0;
+  bool insideTransaction = false;
 };

--- a/Marlin/src/HAL/NATIVE_SIM/sim/hardware/SPISlavePeripheral.h
+++ b/Marlin/src/HAL/NATIVE_SIM/sim/hardware/SPISlavePeripheral.h
@@ -1,0 +1,39 @@
+#include "Gpio.h"
+
+/**
+ * Class to Easily Handle SPI Slave communication
+ */
+class SPISlavePeripheral : Peripheral {
+public:
+  SPISlavePeripheral(pin_type clk, pin_type miso, pin_type mosi, pin_type cs, uint8_t CPOL = 0, uint8_t CPHA = 0);
+  virtual ~SPISlavePeripheral();
+
+  // Callbacks
+  virtual void onBeginTransaction();
+  virtual void onEndTransaction();
+  virtual void onBitReceived(uint8_t _bit);
+  virtual void onBitSent(uint8_t _bit);
+  virtual void onByteReceived(uint8_t _byte);
+  virtual void onResponseSent();
+  virtual void onByteSent(uint8_t _byte);
+
+  void setResponse(uint8_t _data);
+  void setResponse16(uint16_t _data, bool msb = true);
+  void setResponse(uint8_t *_bytes, size_t count);
+
+protected:
+  void transmitCurrentBit();
+  void spiInterrupt(GpioEvent& ev);
+
+  pin_type clk_pin, miso_pin, mosi_pin, cs_pin;
+  uint8_t CPOL, CPHA;
+
+private:
+  uint8_t incomming_byte = 0;
+  uint8_t incomming_bit_count = 0;
+  uint8_t incomming_byte_count = 0;
+  uint8_t outgoing_byte = 0xFF;
+  uint8_t outgoing_bit_count = 0;
+  uint8_t *responseData = nullptr;
+  size_t responseDataSize = 0;
+};

--- a/Marlin/src/HAL/NATIVE_SIM/sim/hardware/SPISlavePeripheral.h
+++ b/Marlin/src/HAL/NATIVE_SIM/sim/hardware/SPISlavePeripheral.h
@@ -39,4 +39,5 @@ private:
   uint8_t *responseData = nullptr;
   size_t responseDataSize = 0;
   bool insideTransaction = false;
+  bool hasDataToSend = false;
 };

--- a/Marlin/src/HAL/NATIVE_SIM/sim/hardware/SPISlavePeripheral.h
+++ b/Marlin/src/HAL/NATIVE_SIM/sim/hardware/SPISlavePeripheral.h
@@ -29,9 +29,9 @@ protected:
   uint8_t CPOL, CPHA;
 
 private:
-  uint8_t incomming_byte = 0;
-  uint8_t incomming_bit_count = 0;
-  uint8_t incomming_byte_count = 0;
+  uint8_t incoming_byte = 0;
+  uint8_t incoming_bit_count = 0;
+  uint8_t incoming_byte_count = 0;
   uint8_t outgoing_byte = 0xFF;
   uint8_t outgoing_bit_count = 0;
   uint8_t *responseData = nullptr;

--- a/Marlin/src/HAL/NATIVE_SIM/sim/hardware/SPISlavePeripheral.h
+++ b/Marlin/src/HAL/NATIVE_SIM/sim/hardware/SPISlavePeripheral.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "Gpio.h"
 
 /**

--- a/Marlin/src/HAL/NATIVE_SIM/sim/hardware/SPISlavePeripheral.h
+++ b/Marlin/src/HAL/NATIVE_SIM/sim/hardware/SPISlavePeripheral.h
@@ -13,15 +13,23 @@ public:
   // Callbacks
   virtual void onBeginTransaction();
   virtual void onEndTransaction();
+
   virtual void onBitReceived(uint8_t _bit);
-  virtual void onBitSent(uint8_t _bit);
   virtual void onByteReceived(uint8_t _byte);
-  virtual void onResponseSent();
+  virtual void onRequestedDataReceived(uint8_t token, uint8_t* _data, size_t count);
+
+  virtual void onBitSent(uint8_t _bit);
   virtual void onByteSent(uint8_t _byte);
+  virtual void onResponseSent();
+
 
   void setResponse(uint8_t _data);
   void setResponse16(uint16_t _data, bool msb = true);
   void setResponse(uint8_t *_bytes, size_t count);
+
+  void setRequestedDataSize(uint8_t token, size_t _count);
+
+  uint8_t getCurrentToken() { return currentToken; }
 
 protected:
   void transmitCurrentBit();
@@ -40,4 +48,8 @@ private:
   size_t responseDataSize = 0;
   bool insideTransaction = false;
   bool hasDataToSend = false;
+  uint8_t currentToken = 0xFF;
+  uint8_t *requestedData = nullptr;
+  size_t requestedDataSize = 0;
+  size_t requestedDataIndex = 0;
 };

--- a/Marlin/src/HAL/NATIVE_SIM/sim/hardware/ST7796Device.cpp
+++ b/Marlin/src/HAL/NATIVE_SIM/sim/hardware/ST7796Device.cpp
@@ -1,0 +1,127 @@
+#ifdef __PLAT_NATIVE_SIM__
+
+#include <mutex>
+#include <fstream>
+#include <cmath>
+#include <random>
+#include "Gpio.h"
+
+#include <GL/glew.h>
+#include <GL/gl.h>
+
+#include "ST7796Device.h"
+
+#include "../../tft/xpt2046.h"
+
+#define ST7796S_CASET      0x2A // Column Address Set
+#define ST7796S_RASET      0x2B // Row Address Set
+#define ST7796S_RAMWR      0x2C // Memory Write
+
+ST7796Device::ST7796Device(pin_type clk, pin_type mosi, pin_type cs, pin_type dc, pin_type beeper, pin_type enc1, pin_type enc2, pin_type enc_but, pin_type kill)
+  : clk_pin(clk), mosi_pin(mosi), cs_pin(cs), dc_pin(dc), beeper_pin(beeper), enc1_pin(enc1), enc2_pin(enc2), enc_but_pin(enc_but), kill_pin(kill), touch(TOUCH_SCK_PIN, TOUCH_MOSI_PIN, TOUCH_CS_PIN, TOUCH_MISO_PIN)
+  {
+
+  Gpio::attach(clk_pin, [this](GpioEvent& event){ this->interrupt(event); });
+  Gpio::attach(cs_pin, [this](GpioEvent& event){ this->interrupt(event); });
+  Gpio::attach(dc_pin, [this](GpioEvent& event){ this->interrupt(event); });
+  Gpio::attach(beeper_pin, [this](GpioEvent& event){ this->interrupt(event); });
+  Gpio::attach(kill_pin, [this](GpioEvent& event){ this->interrupt(event); });
+  Gpio::attach(enc_but_pin, [this](GpioEvent& event){ this->interrupt(event); });
+  Gpio::attach(enc1_pin, [this](GpioEvent& event){ this->interrupt(event); });
+  Gpio::attach(enc2_pin, [this](GpioEvent& event){ this->interrupt(event); });
+
+  glGenTextures(1, &texture_id);
+  glBindTexture(GL_TEXTURE_2D, texture_id);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  glBindTexture(GL_TEXTURE_2D, 0);
+}
+
+ST7796Device::~ST7796Device() {}
+
+void ST7796Device::process_command(Command cmd) {
+  if (cmd.cmd == ST7796S_CASET) {
+    xMin = (cmd.data[0] << 8) + cmd.data[1];
+    xMax = (cmd.data[2] << 8) + cmd.data[3];
+    graphic_ram_index_x = xMin;
+  }
+  else if (cmd.cmd == ST7796S_RASET) {
+    yMin = (cmd.data[0] << 8) + cmd.data[1];
+    yMax = (cmd.data[2] << 8) + cmd.data[3];
+    graphic_ram_index_y = yMin;
+  }
+  else if (cmd.cmd == ST7796S_RAMWR) {
+    for(int i = 0; i < cmd.data.size(); i += 2) {
+      auto pixel = (cmd.data[i] << 8) + cmd.data[i+1];
+      graphic_ram[graphic_ram_index_x + (graphic_ram_index_y * 480)] = pixel;
+      if (graphic_ram_index_x >= xMax) {
+        graphic_ram_index_x = xMin;
+        graphic_ram_index_y++;
+      }
+      else {
+        graphic_ram_index_x++;
+      }
+    }
+    if (graphic_ram_index_y >= yMax && graphic_ram_index_x >= xMax) {
+      dirty = true;
+    }
+  }
+}
+
+void ST7796Device::update() {
+  auto now = clock.now();
+  float delta = std::chrono::duration_cast<std::chrono::duration<float>>(now - last_update).count();
+
+  if (dirty && delta > 1.0 / 30.0) {
+    last_update = now;
+    glBindTexture(GL_TEXTURE_2D, texture_id);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, 480, 320, 0, GL_RGB, GL_UNSIGNED_SHORT_5_6_5, graphic_ram);
+    glBindTexture(GL_TEXTURE_2D, 0);
+  }
+}
+
+static uint8_t command = 0;
+static std::vector<uint8_t> data;
+
+void ST7796Device::interrupt(GpioEvent& ev) {
+  if (ev.pin_id == clk_pin && ev.event == GpioEvent::FALL && Gpio::pin_map[cs_pin].value == 0) {
+    incomming_byte = (incomming_byte << 1) | Gpio::pin_map[mosi_pin].value;
+    if (++incomming_bit_count == 8) {
+      if (Gpio::pin_map[dc_pin].value) {
+        //data
+        data.push_back(incomming_byte);
+      }
+      else {
+        //command
+        command = incomming_byte;
+      }
+      incomming_bit_count = 0;
+    }
+  } else if (ev.pin_id == cs_pin && ev.event == GpioEvent::RISE) {
+    //end of transaction, execute pending command
+    incomming_bit_count = incomming_byte_count = incomming_byte = 0;
+    process_command({command, data});
+    data.clear();
+  } else if (ev.pin_id == beeper_pin) {
+    if (ev.event == GpioEvent::RISE) {
+      // play sound
+    } else if (ev.event == GpioEvent::FALL) {
+      // stop sound
+    }
+  } else if (ev.pin_id == dc_pin && ev.event == GpioEvent::FALL) {
+    //start new command, execute last one
+    process_command({command, data});
+    data.clear();
+  }
+}
+
+void ST7796Device::ui_callback(UiWindow* window) {
+  if (ImGui::IsWindowFocused()) {
+    touch.ui_callback(window);
+  }
+}
+
+#endif
+

--- a/Marlin/src/HAL/NATIVE_SIM/sim/hardware/ST7796Device.h
+++ b/Marlin/src/HAL/NATIVE_SIM/sim/hardware/ST7796Device.h
@@ -33,6 +33,9 @@ public:
   void onByteReceived(uint8_t _byte) override;
   void onEndTransaction() override;
 
+  static constexpr uint32_t width = 480;
+  static constexpr uint32_t height = 320;
+
   pin_type dc_pin, beeper_pin, enc1_pin, enc2_pin, enc_but_pin, kill_pin;
 
   uint8_t command = 0;
@@ -40,7 +43,7 @@ public:
   uint8_t incomming_cmd[3] = {};
   std::deque<Command> cmd_in;
 
-  static constexpr uint32_t graphic_ram_size = 480 * 320;
+  static constexpr uint32_t graphic_ram_size = width * height;
   uint16_t graphic_ram[graphic_ram_size] = {}; // 64 x 256bit
   uint16_t graphic_ram_index = 0;
   uint16_t graphic_ram_index_x = 0, graphic_ram_index_y = 0;

--- a/Marlin/src/HAL/NATIVE_SIM/sim/hardware/ST7796Device.h
+++ b/Marlin/src/HAL/NATIVE_SIM/sim/hardware/ST7796Device.h
@@ -7,10 +7,12 @@
 #include <deque>
 #include "Gpio.h"
 
+#include "SPISlavePeripheral.h"
 #include "XPT2046Device.h"
 
-class ST7796Device: public Peripheral {
+class ST7796Device: public SPISlavePeripheral {
 public:
+  //TODO: support encoder in the TFT
   enum KeyName {
     KILL_BUTTON, ENCODER_BUTTON, COUNT
   };
@@ -21,18 +23,20 @@ public:
     std::vector<uint8_t> data;
   };
 
-  ST7796Device(pin_type clk, pin_type mosi, pin_type cs, pin_type dc, pin_type beeper, pin_type enc1, pin_type enc2, pin_type enc_but, pin_type kill);
+  ST7796Device(pin_type clk, pin_type miso, pin_type mosi, pin_type tft_cs, pin_type touch_cs, pin_type dc, pin_type beeper, pin_type enc1, pin_type enc2, pin_type enc_but, pin_type kill);
   virtual ~ST7796Device();
   void process_command(Command cmd);
   void update();
   void interrupt(GpioEvent& ev);
   void ui_callback(UiWindow* window);
 
-  pin_type clk_pin, mosi_pin, cs_pin, dc_pin, beeper_pin, enc1_pin, enc2_pin, enc_but_pin, kill_pin;
+  void onByteReceived(uint8_t _byte) override;
+  void onEndTransaction() override;
 
-  uint8_t incomming_byte = 0;
-  uint8_t incomming_bit_count = 0;
-  uint8_t incomming_byte_count = 0;
+  pin_type dc_pin, beeper_pin, enc1_pin, enc2_pin, enc_but_pin, kill_pin;
+
+  uint8_t command = 0;
+  std::vector<uint8_t> data;
   uint8_t incomming_cmd[3] = {};
   std::deque<Command> cmd_in;
 

--- a/Marlin/src/HAL/NATIVE_SIM/sim/hardware/ST7796Device.h
+++ b/Marlin/src/HAL/NATIVE_SIM/sim/hardware/ST7796Device.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <SDL2/SDL.h>
+#include "../user_interface.h"
+
+#include <list>
+#include <deque>
+#include "Gpio.h"
+
+#include "XPT2046Device.h"
+
+class ST7796Device: public Peripheral {
+public:
+  enum KeyName {
+    KILL_BUTTON, ENCODER_BUTTON, COUNT
+  };
+
+  struct Command {
+    Command(uint8_t cmd, std::vector<uint8_t> data) : cmd(cmd), data(data){};
+    uint8_t cmd = 0;
+    std::vector<uint8_t> data;
+  };
+
+  ST7796Device(pin_type clk, pin_type mosi, pin_type cs, pin_type dc, pin_type beeper, pin_type enc1, pin_type enc2, pin_type enc_but, pin_type kill);
+  virtual ~ST7796Device();
+  void process_command(Command cmd);
+  void update();
+  void interrupt(GpioEvent& ev);
+  void ui_callback(UiWindow* window);
+
+  pin_type clk_pin, mosi_pin, cs_pin, dc_pin, beeper_pin, enc1_pin, enc2_pin, enc_but_pin, kill_pin;
+
+  uint8_t incomming_byte = 0;
+  uint8_t incomming_bit_count = 0;
+  uint8_t incomming_byte_count = 0;
+  uint8_t incomming_cmd[3] = {};
+  std::deque<Command> cmd_in;
+
+  static constexpr uint32_t graphic_ram_size = 480 * 320;
+  uint16_t graphic_ram[graphic_ram_size] = {}; // 64 x 256bit
+  uint16_t graphic_ram_index = 0;
+  uint16_t graphic_ram_index_x = 0, graphic_ram_index_y = 0;
+
+  uint32_t address_counter = 0;
+  int8_t address_increment = 1;
+
+  uint16_t xMin = 0;
+  uint16_t xMax = 0;
+  uint16_t yMin = 0;
+  uint16_t yMax = 0;
+
+  bool key_pressed[KeyName::COUNT] = {};
+  uint8_t encoder_position = 0.0f;
+  static constexpr int8_t encoder_table[4] = {1, 3, 2, 0};
+
+  bool dirty = true;
+  std::chrono::steady_clock clock;
+  std::chrono::steady_clock::time_point last_update;
+  float scaler;
+  GLuint texture_id;
+
+  XPT2046Device touch;
+};

--- a/Marlin/src/HAL/NATIVE_SIM/sim/hardware/ST7920Device.h
+++ b/Marlin/src/HAL/NATIVE_SIM/sim/hardware/ST7920Device.h
@@ -27,6 +27,9 @@ public:
   void interrupt(GpioEvent& ev);
   void ui_callback(UiWindow* window);
 
+  static constexpr uint32_t width = 128;
+  static constexpr uint32_t height = 64;
+
   pin_type clk_pin, mosi_pin, cs_pin, beeper_pin, enc1_pin, enc2_pin, enc_but_pin, kill_pin;
 
   bool extended_instruction_set = false;

--- a/Marlin/src/HAL/NATIVE_SIM/sim/hardware/W25QxxDevice.cpp
+++ b/Marlin/src/HAL/NATIVE_SIM/sim/hardware/W25QxxDevice.cpp
@@ -1,0 +1,66 @@
+#include "W25QxxDevice.h"
+#include "src/libs/W25Qxx.h"
+
+void W25QxxDevice::onByteReceived(uint8_t _byte) {
+  SPISlavePeripheral::onByteReceived(_byte);
+  if (getCurrentToken() != 0xFF) return;
+
+  switch (_byte) {
+    case W25X_PageProgram:
+    case W25X_ReadData:
+    case W25X_SectorErase:
+    case W25X_BlockErase:
+      setRequestedDataSize(_byte, 3);
+      break;
+    case W25X_WriteEnable:
+      break;
+    case W25X_ReadStatusReg:
+      fp = fopen(SPI_FLASH_IMAGE, "wb");
+      fwrite(data, 1, flash_size, fp);
+      fclose(fp);
+      fp = nullptr;
+      setResponse(0);
+      break;
+    default:
+      break;
+  }
+};
+
+void W25QxxDevice::onRequestedDataReceived(uint8_t token, uint8_t* _data, size_t count) {
+  SPISlavePeripheral::onRequestedDataReceived(token, _data, count);
+  switch (token) {
+    case W25X_ReadData:
+      currentAddress = (_data[0] << 16) | (_data[1] << 8) | _data[2];
+      setResponse(data + currentAddress, flash_size - currentAddress);
+      currentAddress = -1;
+      break;
+    case W25X_PageProgram:
+      // receivind data to write!
+      if (currentAddress > -1) {
+        for(size_t i = 0; i < count; i++) data[i + currentAddress] = _data[i];
+        currentAddress = -1;
+      }
+      else {
+        currentAddress = (_data[0] << 16) | (_data[1] << 8) | _data[2];
+        setRequestedDataSize(W25X_PageProgram, SPI_FLASH_PerWritePageSize);
+      }
+      break;
+    case W25X_SectorErase:
+      currentAddress = (_data[0] << 16) | (_data[1] << 8) | _data[2];
+      memset(data + currentAddress, 0xFF, SPI_FLASH_SectorSize);
+      currentAddress = -1;
+      break;
+    case W25X_BlockErase:
+      currentAddress = (_data[0] << 16) | (_data[1] << 8) | _data[2];
+      memset(data + currentAddress, 0xFF, 65536); //64kb
+      currentAddress = -1;
+      break;
+    default:
+      break;
+  }
+
+}
+
+void W25QxxDevice::onEndTransaction() {
+  SPISlavePeripheral::onEndTransaction();
+}

--- a/Marlin/src/HAL/NATIVE_SIM/sim/hardware/W25QxxDevice.h
+++ b/Marlin/src/HAL/NATIVE_SIM/sim/hardware/W25QxxDevice.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "../user_interface.h"
+
+#include "SPISlavePeripheral.h"
+
+/**
+ * SPI Flash W25Qxx device
+ **/
+ #define SPI_FLASH_IMAGE "./spi_flash.bin"
+ #ifndef SPI_FLASH_IMAGE
+   #error "You need set SPI_FLASH_IMAGE to keep SPI FLASH data."
+ #endif
+
+class W25QxxDevice: public SPISlavePeripheral {
+public:
+  W25QxxDevice(pin_type clk, pin_type mosi, pin_type miso, pin_type cs, size_t flash_size) : SPISlavePeripheral(clk, mosi, miso, cs), flash_size(flash_size) {
+    // read current data
+    fp = fopen(SPI_FLASH_IMAGE, "rb+");
+    data = new uint8_t[flash_size];
+    memset(data, 0xFF, flash_size);
+    fread(data, 1, flash_size, fp);
+    fclose(fp);
+  }
+  virtual ~W25QxxDevice() {
+  };
+
+  size_t flash_size;
+
+  void update() {};
+  void ui_callback(UiWindow* window) {};
+
+  void onByteReceived(uint8_t _byte) override;
+  void onEndTransaction() override;
+  void onRequestedDataReceived(uint8_t token, uint8_t* _data, size_t count) override;
+
+  FILE *fp = nullptr;
+  uint8_t *data;
+  int32_t currentAddress = -1;
+};

--- a/Marlin/src/HAL/NATIVE_SIM/sim/hardware/XPT2046Device.cpp
+++ b/Marlin/src/HAL/NATIVE_SIM/sim/hardware/XPT2046Device.cpp
@@ -1,0 +1,103 @@
+#ifdef __PLAT_NATIVE_SIM__
+
+#include <mutex>
+#include <fstream>
+#include <cmath>
+#include <random>
+#include "Gpio.h"
+
+#include <GL/glew.h>
+#include <GL/gl.h>
+
+#include "XPT2046Device.h"
+#include "../../tft/xpt2046.h"
+
+
+XPT2046Device::XPT2046Device(pin_type clk, pin_type mosi, pin_type cs, pin_type miso)
+  : clk_pin(clk), mosi_pin(mosi), miso_pin(miso), cs_pin(cs) {
+
+  Gpio::attach(clk_pin, [this](GpioEvent& event){ this->interrupt(event); });
+  Gpio::attach(cs_pin, [this](GpioEvent& event){ this->interrupt(event); });
+  // Gpio::attach(miso_pin, [this](GpioEvent& event){ this->interrupt(event); });
+  Gpio::attach(mosi_pin, [this](GpioEvent& event){ this->interrupt(event); });
+}
+
+XPT2046Device::~XPT2046Device() {}
+
+void XPT2046Device::update() {
+  static uint16_t buffer[480*320] = {};
+  auto now = clock.now();
+  float delta = std::chrono::duration_cast<std::chrono::duration<float>>(now - last_update).count();
+
+  // if (dirty && delta > 1.0 / 30.0) {
+  //   last_update = now;
+  // }
+}
+
+uint8_t current_state = 0;
+
+void trasmit(pin_type miso_pin, uint16_t value, uint8_t incomming_byte_count, uint8_t incomming_bit_count) {
+  if (incomming_byte_count == 0)
+    Gpio::pin_map[miso_pin].value = !!((value >> (15 - incomming_bit_count)) & 1);
+  else if (incomming_byte_count == 1)
+    Gpio::pin_map[miso_pin].value = !!((value >> (7 - incomming_bit_count)) & 1);
+  else
+    Gpio::pin_map[miso_pin].value = 0;
+}
+
+void XPT2046Device::interrupt(GpioEvent& ev) {
+  if (ev.pin_id == mosi_pin && Gpio::pin_map[cs_pin].value == 0) {
+    if (current_state == XPT2046_X) {
+      trasmit(miso_pin, clickX, incomming_byte_count, incomming_bit_count);
+    }
+    else if (current_state == XPT2046_Y) {
+      trasmit(miso_pin, clickY, incomming_byte_count, incomming_bit_count);
+      dirty = false;
+    }
+    else if (current_state == XPT2046_Z1 && dirty) {
+      trasmit(miso_pin, XPT2046_Z1_THRESHOLD, incomming_byte_count, incomming_bit_count);
+    }
+    else {
+      Gpio::pin_map[miso_pin].value = 0;
+    }
+    if (current_state == XPT2046_Z1 && dirty && incomming_byte_count > 2) {
+      current_state = 0;
+    }
+  }
+  else if (ev.pin_id == clk_pin && ev.event == GpioEvent::FALL && Gpio::pin_map[cs_pin].value == 0) {
+    incomming_byte = (incomming_byte << 1) | Gpio::pin_map[mosi_pin].value;
+    if (++incomming_bit_count == 8) {
+      incomming_bit_count = 0;
+      incomming_byte_count++;
+      if (incomming_byte == XPT2046_X) {
+        // printf("Asking X   \n");
+        current_state = XPT2046_X;
+        incomming_byte_count = 0;
+      }
+      else if (incomming_byte == XPT2046_Y) {
+        // printf("Asking Y\n");
+        current_state = XPT2046_Y;
+        incomming_byte_count = 0;
+      }
+      else if (incomming_byte == XPT2046_Z1) {
+        // printf("Asking Z1\n");
+        current_state = XPT2046_Z1;
+        incomming_byte_count = 0;
+      }
+    }
+  } else if (ev.pin_id == cs_pin && ev.event == GpioEvent::RISE) {
+    //end data
+    incomming_bit_count = incomming_byte_count = incomming_byte = 0;
+    current_state = 0;
+  }
+}
+
+void XPT2046Device::ui_callback(UiWindow* window) {
+  if (ImGui::IsWindowFocused() && ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
+    clickX = ImGui::GetIO().MousePos.x;
+    clickY = ImGui::GetIO().MousePos.y;
+    dirty = true;
+  }
+}
+
+#endif

--- a/Marlin/src/HAL/NATIVE_SIM/sim/hardware/XPT2046Device.cpp
+++ b/Marlin/src/HAL/NATIVE_SIM/sim/hardware/XPT2046Device.cpp
@@ -12,91 +12,38 @@
 #include "XPT2046Device.h"
 #include "../../tft/xpt2046.h"
 
-
-XPT2046Device::XPT2046Device(pin_type clk, pin_type mosi, pin_type cs, pin_type miso)
-  : clk_pin(clk), mosi_pin(mosi), miso_pin(miso), cs_pin(cs) {
-
-  Gpio::attach(clk_pin, [this](GpioEvent& event){ this->interrupt(event); });
-  Gpio::attach(cs_pin, [this](GpioEvent& event){ this->interrupt(event); });
-  // Gpio::attach(miso_pin, [this](GpioEvent& event){ this->interrupt(event); });
-  Gpio::attach(mosi_pin, [this](GpioEvent& event){ this->interrupt(event); });
-}
-
-XPT2046Device::~XPT2046Device() {}
-
-void XPT2046Device::update() {
-  static uint16_t buffer[480*320] = {};
-  auto now = clock.now();
-  float delta = std::chrono::duration_cast<std::chrono::duration<float>>(now - last_update).count();
-
-  // if (dirty && delta > 1.0 / 30.0) {
-  //   last_update = now;
-  // }
-}
-
-uint8_t current_state = 0;
-
-void trasmit(pin_type miso_pin, uint16_t value, uint8_t incomming_byte_count, uint8_t incomming_bit_count) {
-  if (incomming_byte_count == 0)
-    Gpio::pin_map[miso_pin].value = !!((value >> (15 - incomming_bit_count)) & 1);
-  else if (incomming_byte_count == 1)
-    Gpio::pin_map[miso_pin].value = !!((value >> (7 - incomming_bit_count)) & 1);
-  else
-    Gpio::pin_map[miso_pin].value = 0;
-}
-
-void XPT2046Device::interrupt(GpioEvent& ev) {
-  if (ev.pin_id == mosi_pin && Gpio::pin_map[cs_pin].value == 0) {
-    if (current_state == XPT2046_X) {
-      trasmit(miso_pin, clickX, incomming_byte_count, incomming_bit_count);
-    }
-    else if (current_state == XPT2046_Y) {
-      trasmit(miso_pin, clickY, incomming_byte_count, incomming_bit_count);
-      dirty = false;
-    }
-    else if (current_state == XPT2046_Z1 && dirty) {
-      trasmit(miso_pin, XPT2046_Z1_THRESHOLD, incomming_byte_count, incomming_bit_count);
-    }
-    else {
-      Gpio::pin_map[miso_pin].value = 0;
-    }
-    if (current_state == XPT2046_Z1 && dirty && incomming_byte_count > 2) {
-      current_state = 0;
-    }
-  }
-  else if (ev.pin_id == clk_pin && ev.event == GpioEvent::FALL && Gpio::pin_map[cs_pin].value == 0) {
-    incomming_byte = (incomming_byte << 1) | Gpio::pin_map[mosi_pin].value;
-    if (++incomming_bit_count == 8) {
-      incomming_bit_count = 0;
-      incomming_byte_count++;
-      if (incomming_byte == XPT2046_X) {
-        // printf("Asking X   \n");
-        current_state = XPT2046_X;
-        incomming_byte_count = 0;
+void XPT2046Device::onByteReceived(uint8_t _byte) {
+  SPISlavePeripheral::onByteReceived(_byte);
+  switch (_byte) {
+    case XPT2046_Z1:
+      if (dirty) {
+        setResponse16(XPT2046_Z1_THRESHOLD); // respond that we have data to send
       }
-      else if (incomming_byte == XPT2046_Y) {
-        // printf("Asking Y\n");
-        current_state = XPT2046_Y;
-        incomming_byte_count = 0;
+      else {
+        setResponse16(0);
       }
-      else if (incomming_byte == XPT2046_Z1) {
-        // printf("Asking Z1\n");
-        current_state = XPT2046_Z1;
-        incomming_byte_count = 0;
-      }
-    }
-  } else if (ev.pin_id == cs_pin && ev.event == GpioEvent::RISE) {
-    //end data
-    incomming_bit_count = incomming_byte_count = incomming_byte = 0;
-    current_state = 0;
+      break;
+
+    case XPT2046_X:
+      setResponse16(lastClickX);
+      break;
+
+    case XPT2046_Y:
+      setResponse16(lastClickY);
+      break;
+
+    default:
+      break;
   }
 }
+
 
 void XPT2046Device::ui_callback(UiWindow* window) {
   if (ImGui::IsWindowFocused() && ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
-    clickX = ImGui::GetIO().MousePos.x;
-    clickY = ImGui::GetIO().MousePos.y;
+    lastClickX = ImGui::GetIO().MousePos.x;
+    lastClickY = ImGui::GetIO().MousePos.y;
     dirty = true;
+    // printf("click x: %d, y: %d\n", lastClickX, lastClickY);
   }
 }
 

--- a/Marlin/src/HAL/NATIVE_SIM/sim/hardware/XPT2046Device.cpp
+++ b/Marlin/src/HAL/NATIVE_SIM/sim/hardware/XPT2046Device.cpp
@@ -15,6 +15,7 @@
 void XPT2046Device::onByteReceived(uint8_t _byte) {
   SPISlavePeripheral::onByteReceived(_byte);
   switch (_byte) {
+    //TODO: touch hold
     case XPT2046_Z1:
       if (dirty) {
         setResponse16(XPT2046_Z1_THRESHOLD); // respond that we have data to send

--- a/Marlin/src/HAL/NATIVE_SIM/sim/hardware/XPT2046Device.h
+++ b/Marlin/src/HAL/NATIVE_SIM/sim/hardware/XPT2046Device.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <SDL2/SDL.h>
+#include "../user_interface.h"
+
+#include <list>
+#include <deque>
+#include "Gpio.h"
+
+class XPT2046Device: public Peripheral {
+public:
+  XPT2046Device(pin_type clk, pin_type mosi, pin_type cs, pin_type miso);
+  virtual ~XPT2046Device();
+  void update();
+  void interrupt(GpioEvent& ev);
+  void ui_callback(UiWindow* window);
+
+  pin_type clk_pin, mosi_pin, cs_pin, miso_pin;
+
+  uint8_t incomming_byte = 0;
+  uint8_t incomming_bit_count = 0;
+  uint8_t incomming_byte_count = 0;
+
+  bool dirty = false;
+  uint16_t clickX = 0;
+  uint16_t clickY = 0;
+  std::chrono::steady_clock clock;
+  std::chrono::steady_clock::time_point last_update;
+  float scaler;
+};

--- a/Marlin/src/HAL/NATIVE_SIM/sim/hardware/XPT2046Device.h
+++ b/Marlin/src/HAL/NATIVE_SIM/sim/hardware/XPT2046Device.h
@@ -5,26 +5,23 @@
 
 #include <list>
 #include <deque>
-#include "Gpio.h"
+#include "SPISlavePeripheral.h"
 
-class XPT2046Device: public Peripheral {
+class XPT2046Device: public SPISlavePeripheral {
 public:
-  XPT2046Device(pin_type clk, pin_type mosi, pin_type cs, pin_type miso);
-  virtual ~XPT2046Device();
-  void update();
-  void interrupt(GpioEvent& ev);
+  XPT2046Device(pin_type clk, pin_type mosi, pin_type miso, pin_type cs) : SPISlavePeripheral(clk, mosi, miso, cs) {}
+  virtual ~XPT2046Device() {};
+
+  void update() {}
   void ui_callback(UiWindow* window);
 
-  pin_type clk_pin, mosi_pin, cs_pin, miso_pin;
+  void onByteReceived(uint8_t _byte) override;
+  void onEndTransaction() override {
+    SPISlavePeripheral::onEndTransaction();
+    dirty = false;
+  };
 
-  uint8_t incomming_byte = 0;
-  uint8_t incomming_bit_count = 0;
-  uint8_t incomming_byte_count = 0;
-
+  uint16_t lastClickX = 0;
+  uint16_t lastClickY = 0;
   bool dirty = false;
-  uint16_t clickX = 0;
-  uint16_t clickY = 0;
-  std::chrono::steady_clock clock;
-  std::chrono::steady_clock::time_point last_update;
-  float scaler;
 };

--- a/Marlin/src/HAL/NATIVE_SIM/tft/tft_spi.cpp
+++ b/Marlin/src/HAL/NATIVE_SIM/tft/tft_spi.cpp
@@ -1,0 +1,185 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../../../inc/MarlinConfig.h"
+
+#if HAS_SPI_TFT
+
+#include "tft_spi.h"
+
+uint8_t swSpiTransfer_mode_0(uint8_t b, const uint8_t spi_speed, const pin_t sck_pin, const pin_t miso_pin, const pin_t mosi_pin ) {
+  LOOP_L_N(i, 8) {
+    if (spi_speed == 0) {
+      WRITE_PIN(mosi_pin, !!(b & 0x80));
+      WRITE_PIN(sck_pin, HIGH);
+      b <<= 1;
+      if (miso_pin >= 0 && READ_PIN(miso_pin)) b |= 1;
+      WRITE_PIN(sck_pin, LOW);
+    }
+    else {
+      const uint8_t state = (b & 0x80) ? HIGH : LOW;
+      LOOP_L_N(j, spi_speed)
+        WRITE_PIN(mosi_pin, state);
+
+      LOOP_L_N(j, spi_speed + (miso_pin >= 0 ? 0 : 1))
+        WRITE_PIN(sck_pin, HIGH);
+
+      b <<= 1;
+      if (miso_pin >= 0 && READ_PIN(miso_pin)) b |= 1;
+
+      LOOP_L_N(j, spi_speed)
+        WRITE_PIN(sck_pin, LOW);
+    }
+  }
+
+  return b;
+}
+
+//TFT_SPI tft;
+
+#define TFT_CS_H  WRITE(TFT_CS_PIN, HIGH)
+#define TFT_CS_L  WRITE(TFT_CS_PIN, LOW)
+
+#define TFT_DC_H  WRITE(TFT_DC_PIN, HIGH)
+#define TFT_DC_L  WRITE(TFT_DC_PIN, LOW)
+
+#define TFT_RST_H WRITE(TFT_RESET_PIN, HIGH)
+#define TFT_RST_L WRITE(TFT_RESET_PIN, LOW)
+
+#define TFT_BLK_H WRITE(TFT_BACKLIGHT_PIN, HIGH)
+#define TFT_BLK_L WRITE(TFT_BACKLIGHT_PIN, LOW)
+
+void TFT_SPI::Init() {
+  #if PIN_EXISTS(TFT_RESET)
+    SET_OUTPUT(TFT_RESET_PIN);
+    TFT_RST_H;
+    delay(100);
+  #endif
+
+  #if PIN_EXISTS(TFT_BACKLIGHT)
+    SET_OUTPUT(TFT_BACKLIGHT_PIN);
+    TFT_BLK_H;
+  #endif
+
+  SET_OUTPUT(TFT_DC_PIN);
+  SET_OUTPUT(TFT_CS_PIN);
+
+  TFT_DC_H;
+  TFT_CS_H;
+
+  /**
+   * STM32F1 APB2 = 72MHz, APB1 = 36MHz, max SPI speed of this MCU if 18Mhz
+   * STM32F1 has 3 SPI ports, SPI1 in APB2, SPI2/SPI3 in APB1
+   * so the minimum prescale of SPI1 is DIV4, SPI2/SPI3 is DIV2
+   */
+  #if 0
+    #if SPI_DEVICE == 1
+     #define SPI_CLOCK_MAX SPI_CLOCK_DIV4
+    #else
+     #define SPI_CLOCK_MAX SPI_CLOCK_DIV2
+    #endif
+    uint8_t  clock;
+    uint8_t spiRate = SPI_FULL_SPEED;
+    switch (spiRate) {
+     case SPI_FULL_SPEED:    clock = SPI_CLOCK_MAX ;  break;
+     case SPI_HALF_SPEED:    clock = SPI_CLOCK_DIV4 ; break;
+     case SPI_QUARTER_SPEED: clock = SPI_CLOCK_DIV8 ; break;
+     case SPI_EIGHTH_SPEED:  clock = SPI_CLOCK_DIV16; break;
+     case SPI_SPEED_5:       clock = SPI_CLOCK_DIV32; break;
+     case SPI_SPEED_6:       clock = SPI_CLOCK_DIV64; break;
+     default:                clock = SPI_CLOCK_DIV2;  // Default from the SPI library
+    }
+  #endif
+
+  // #if TFT_MISO_PIN == BOARD_SPI1_MISO_PIN
+  //   SPIx.setModule(1);
+  // #elif TFT_MISO_PIN == BOARD_SPI2_MISO_PIN
+  //   SPIx.setModule(2);
+  // #endif
+  // SPIx.setClock(SPI_CLOCK_MAX);
+  // SPIx.setBitOrder(MSBFIRST);
+  // SPIx.setDataMode(SPI_MODE0);
+}
+
+void TFT_SPI::DataTransferBegin(uint16_t DataSize) {
+  // SPIx.setDataSize(DataSize);
+  // SPIx.begin();
+  TFT_CS_L;
+}
+
+uint32_t TFT_SPI::GetID() {
+  uint32_t id;
+  id = ReadID(LCD_READ_ID);
+  if ((id & 0xFFFF) == 0 || (id & 0xFFFF) == 0xFFFF)
+    id = ReadID(LCD_READ_ID4);
+  return id;
+}
+
+uint32_t TFT_SPI::ReadID(uint16_t Reg) {
+  uint32_t data = 0;
+
+  #if PIN_EXISTS(TFT_MISO)
+    uint8_t d = 0;
+    SPIx.setDataSize(DATASIZE_8BIT);
+    SPIx.setClock(SPI_CLOCK_DIV64);
+    SPIx.begin();
+    TFT_CS_L;
+    WriteReg(Reg);
+
+    LOOP_L_N(i, 4) {
+      SPIx.read((uint8_t*)&d, 1);
+      data = (data << 8) | d;
+    }
+
+    DataTransferEnd();
+    SPIx.setClock(SPI_CLOCK_MAX);
+  #endif
+
+  return data >> 7;
+}
+
+bool TFT_SPI::isBusy() {
+  return false;
+}
+
+void TFT_SPI::Abort() {
+  DataTransferEnd();
+}
+
+void TFT_SPI::Transmit(uint16_t Data) {
+  // SPIx.transfer(Data);
+  swSpiTransfer_mode_0(Data, 0, TFT_SCK_PIN, -1, TFT_MOSI_PIN);
+}
+
+void TFT_SPI::TransmitDMA(uint32_t MemoryIncrease, uint16_t *Data, uint16_t Count) {
+  DataTransferBegin();
+  TFT_DC_H;
+  while (Count--)
+  {
+    Transmit(((*Data) >> 8) & 0xFF);
+    Transmit(((*Data) >> 0) & 0xFF);
+    if (MemoryIncrease == DMA_MINC_ENABLE) Data++;
+  }
+  DataTransferEnd();
+}
+
+#endif // HAS_SPI_TFT

--- a/Marlin/src/HAL/NATIVE_SIM/tft/tft_spi.cpp
+++ b/Marlin/src/HAL/NATIVE_SIM/tft/tft_spi.cpp
@@ -26,34 +26,6 @@
 
 #include "tft_spi.h"
 
-uint8_t swSpiTransfer_mode_0(uint8_t b, const uint8_t spi_speed, const pin_t sck_pin, const pin_t miso_pin, const pin_t mosi_pin ) {
-  LOOP_L_N(i, 8) {
-    if (spi_speed == 0) {
-      WRITE_PIN(mosi_pin, !!(b & 0x80));
-      WRITE_PIN(sck_pin, HIGH);
-      b <<= 1;
-      if (miso_pin >= 0 && READ_PIN(miso_pin)) b |= 1;
-      WRITE_PIN(sck_pin, LOW);
-    }
-    else {
-      const uint8_t state = (b & 0x80) ? HIGH : LOW;
-      LOOP_L_N(j, spi_speed)
-        WRITE_PIN(mosi_pin, state);
-
-      LOOP_L_N(j, spi_speed + (miso_pin >= 0 ? 0 : 1))
-        WRITE_PIN(sck_pin, HIGH);
-
-      b <<= 1;
-      if (miso_pin >= 0 && READ_PIN(miso_pin)) b |= 1;
-
-      LOOP_L_N(j, spi_speed)
-        WRITE_PIN(sck_pin, LOW);
-    }
-  }
-
-  return b;
-}
-
 //TFT_SPI tft;
 
 #define TFT_CS_H  WRITE(TFT_CS_PIN, HIGH)
@@ -166,8 +138,7 @@ void TFT_SPI::Abort() {
 }
 
 void TFT_SPI::Transmit(uint16_t Data) {
-  // SPIx.transfer(Data);
-  swSpiTransfer_mode_0(Data, 0, TFT_SCK_PIN, -1, TFT_MOSI_PIN);
+  spiSend(Data);
 }
 
 void TFT_SPI::TransmitDMA(uint32_t MemoryIncrease, uint16_t *Data, uint16_t Count) {

--- a/Marlin/src/HAL/NATIVE_SIM/tft/tft_spi.h
+++ b/Marlin/src/HAL/NATIVE_SIM/tft/tft_spi.h
@@ -1,0 +1,73 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "../../../inc/MarlinConfig.h"
+
+#ifndef LCD_READ_ID
+  #define LCD_READ_ID  0x04   // Read display identification information (0xD3 on ILI9341)
+#endif
+#ifndef LCD_READ_ID4
+  #define LCD_READ_ID4 0xD3   // Read display identification information (0xD3 on ILI9341)
+#endif
+
+#define DATASIZE_8BIT    8
+#define DATASIZE_16BIT   16
+#define TFT_IO_DRIVER TFT_SPI
+
+#define DMA_MINC_ENABLE 1
+#define DMA_MINC_DISABLE 0
+
+class TFT_SPI {
+private:
+  static uint32_t ReadID(uint16_t Reg);
+  static void Transmit(uint16_t Data);
+  static void TransmitDMA(uint32_t MemoryIncrease, uint16_t *Data, uint16_t Count);
+
+public:
+  // static SPIClass SPIx;
+
+  static void Init();
+  static uint32_t GetID();
+  static bool isBusy();
+  static void Abort();
+
+  static void DataTransferBegin(uint16_t DataWidth = DATASIZE_16BIT);
+  static void DataTransferEnd() { OUT_WRITE(TFT_CS_PIN, HIGH); };
+  static void DataTransferAbort();
+
+  static void WriteData(uint16_t Data) { Transmit(Data); }
+  static void WriteReg(uint16_t Reg) { OUT_WRITE(TFT_A0_PIN, LOW); Transmit(Reg); OUT_WRITE(TFT_A0_PIN, HIGH); }
+
+  static void WriteSequence(uint16_t *Data, uint16_t Count) { TransmitDMA(DMA_MINC_ENABLE, Data, Count); }
+  // static void WriteMultiple(uint16_t Color, uint16_t Count) { static uint16_t Data; Data = Color; TransmitDMA(DMA_MINC_DISABLE, &Data, Count); }
+  static void WriteMultiple(uint16_t Color, uint32_t Count) {
+    static uint16_t Data; Data = Color;
+    //LPC dma can only write 0xFFF bytes at once.
+    #define MAX_DMA_SIZE (0xFFF - 1)
+    while (Count > 0) {
+      TransmitDMA(DMA_MINC_DISABLE, &Data, Count > MAX_DMA_SIZE ? MAX_DMA_SIZE : Count);
+      Count = Count > MAX_DMA_SIZE ? Count - MAX_DMA_SIZE : 0;
+    }
+    #undef MAX_DMA_SIZE
+  }
+};

--- a/Marlin/src/HAL/NATIVE_SIM/tft/xpt2046.cpp
+++ b/Marlin/src/HAL/NATIVE_SIM/tft/xpt2046.cpp
@@ -1,0 +1,139 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2019 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../../../inc/MarlinConfig.h"
+
+#if HAS_TFT_XPT2046 || HAS_TOUCH_XPT2046
+
+#include "xpt2046.h"
+// #include <SPI.h>
+
+uint16_t delta(uint16_t a, uint16_t b) { return a > b ? a - b : b - a; }
+
+#if ENABLED(TOUCH_BUTTONS_HW_SPI)
+  #include <SPI.h>
+
+  SPIClass XPT2046::SPIx(TOUCH_BUTTONS_HW_SPI_DEVICE);
+
+  static void touch_spi_init(uint8_t spiRate) {
+    XPT2046::SPIx.setModule(TOUCH_BUTTONS_HW_SPI_DEVICE);
+    XPT2046::SPIx.setClock(SPI_CLOCK_DIV128);
+    XPT2046::SPIx.setBitOrder(MSBFIRST);
+    XPT2046::SPIx.setDataMode(SPI_MODE0);
+    XPT2046::SPIx.setDataSize(DATA_SIZE_8BIT);
+  }
+#endif
+
+void XPT2046::Init() {
+  SET_INPUT(TOUCH_MISO_PIN);
+  SET_OUTPUT(TOUCH_MOSI_PIN);
+  SET_OUTPUT(TOUCH_SCK_PIN);
+  OUT_WRITE(TOUCH_CS_PIN, HIGH);
+
+  #if PIN_EXISTS(TOUCH_INT)
+    // Optional Pendrive interrupt pin
+    SET_INPUT(TOUCH_INT_PIN);
+  #endif
+
+  TERN_(TOUCH_BUTTONS_HW_SPI, touch_spi_init(SPI_SPEED_6));
+
+  // Read once to enable pendrive status pin
+  getRawData(XPT2046_X);
+  int a = getRawData(XPT2046_Z1);
+  SERIAL_ECHOLNPAIR("A: ", a);
+  SERIAL_ECHOLNPAIR("A: ", a);
+}
+
+bool XPT2046::isTouched() {
+  return isBusy() ? false : (
+    #if PIN_EXISTS(TOUCH_INT)
+      READ(TOUCH_INT_PIN) != HIGH
+    #else
+      getRawData(XPT2046_Z1) >= XPT2046_Z1_THRESHOLD
+    #endif
+  );
+}
+
+bool XPT2046::getRawPoint(int16_t *x, int16_t *y) {
+  if (isBusy()) return false;
+  if (!isTouched()) return false;
+  *x = getRawData(XPT2046_X);
+  *y = getRawData(XPT2046_Y);
+  return true; //isTouched();
+}
+
+uint16_t XPT2046::getRawData(const XPTCoordinate coordinate) {
+  uint16_t data[3];
+
+  DataTransferBegin();
+  TERN_(TOUCH_BUTTONS_HW_SPI, SPIx.begin());
+
+  for (uint16_t i = 0; i < 3 ; i++) {
+    IO(coordinate);
+    data[i] = (IO() << 8) | IO();
+  }
+
+  TERN_(TOUCH_BUTTONS_HW_SPI, SPIx.end());
+  DataTransferEnd();
+
+  uint16_t delta01 = delta(data[0], data[1]),
+           delta02 = delta(data[0], data[2]),
+           delta12 = delta(data[1], data[2]);
+
+  if (delta01 > delta02 || delta01 > delta12)
+    data[delta02 > delta12 ? 0 : 1] = data[2];
+
+  return (data[0] + data[1]) >> 1;
+}
+
+uint16_t XPT2046::IO(uint16_t data) {
+  return TERN(TOUCH_BUTTONS_HW_SPI, HardwareIO, SoftwareIO)(data);
+}
+
+extern uint8_t spiTransfer(uint8_t b);
+
+#if ENABLED(TOUCH_BUTTONS_HW_SPI)
+  uint16_t XPT2046::HardwareIO(uint16_t data) {
+    return SPIx.transfer(data & 0xFF);
+  }
+#endif
+
+uint16_t XPT2046::SoftwareIO(uint16_t data) {
+  uint16_t result = 0;
+
+  for (uint8_t j = 0x80; j; j >>= 1) {
+    WRITE(TOUCH_SCK_PIN, LOW);
+    WRITE(TOUCH_MOSI_PIN, data & j ? HIGH : LOW);
+    if (READ(TOUCH_MISO_PIN)) {
+      //printf("TOUCH_MISO_PIN = 1\n");
+      result |= j;
+    }
+    else {
+      //printf("TOUCH_MISO_PIN = 0\n");
+    }
+    WRITE(TOUCH_SCK_PIN, HIGH);
+  }
+  WRITE(TOUCH_SCK_PIN, LOW);
+
+  //printf("result: %d\n", result);
+
+  return result;
+}
+
+#endif // HAS_TFT_XPT2046

--- a/Marlin/src/HAL/NATIVE_SIM/tft/xpt2046.h
+++ b/Marlin/src/HAL/NATIVE_SIM/tft/xpt2046.h
@@ -1,0 +1,80 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2019 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "../../../inc/MarlinConfig.h"
+
+#if ENABLED(TOUCH_BUTTONS_HW_SPI)
+  #include <SPI.h>
+#endif
+
+#ifndef TOUCH_MISO_PIN
+  #define TOUCH_MISO_PIN MISO_PIN
+#endif
+#ifndef TOUCH_MOSI_PIN
+  #define TOUCH_MOSI_PIN MOSI_PIN
+#endif
+#ifndef TOUCH_SCK_PIN
+  #define TOUCH_SCK_PIN  SCK_PIN
+#endif
+#ifndef TOUCH_CS_PIN
+  #define TOUCH_CS_PIN   CS_PIN
+#endif
+#ifndef TOUCH_INT_PIN
+  #define TOUCH_INT_PIN  -1
+#endif
+
+#define XPT2046_DFR_MODE        0x00
+#define XPT2046_SER_MODE        0x04
+#define XPT2046_CONTROL         0x80
+
+enum XPTCoordinate : uint8_t {
+  XPT2046_X  = 0x10 | XPT2046_CONTROL | XPT2046_DFR_MODE,
+  XPT2046_Y  = 0x50 | XPT2046_CONTROL | XPT2046_DFR_MODE,
+  XPT2046_Z1 = 0x30 | XPT2046_CONTROL | XPT2046_DFR_MODE,
+  XPT2046_Z2 = 0x40 | XPT2046_CONTROL | XPT2046_DFR_MODE,
+};
+
+#if !defined(XPT2046_Z1_THRESHOLD)
+  #define XPT2046_Z1_THRESHOLD 10
+#endif
+
+class XPT2046 {
+private:
+  static bool isBusy() { return false; }
+
+  static uint16_t getRawData(const XPTCoordinate coordinate);
+  static bool isTouched();
+
+  static inline void DataTransferBegin() { WRITE(TOUCH_CS_PIN, LOW); };
+  static inline void DataTransferEnd() { WRITE(TOUCH_CS_PIN, HIGH); };
+  #if ENABLED(TOUCH_BUTTONS_HW_SPI)
+    static uint16_t HardwareIO(uint16_t data);
+  #endif
+  static uint16_t SoftwareIO(uint16_t data);
+  static uint16_t IO(uint16_t data = 0);
+
+public:
+  #if ENABLED(TOUCH_BUTTONS_HW_SPI)
+    static SPIClass SPIx;
+  #endif
+
+  static void Init();
+  static bool getRawPoint(int16_t *x, int16_t *y);
+};

--- a/Marlin/src/HAL/NATIVE_SIM/timers.cpp
+++ b/Marlin/src/HAL/NATIVE_SIM/timers.cpp
@@ -74,6 +74,10 @@ extern Kernel kernel;
 void HAL_timer_init() {
   kernel.timerInit(STEP_TIMER_NUM, STEPPER_TIMER_RATE);
   kernel.timerInit(TEMP_TIMER_NUM, TEMP_TIMER_RATE);
+  // Configure and start systick early
+  kernel.timerInit(SYSTICK_TIMER_NUM, HAL_TIMER_RATE);
+  HAL_timer_enable_interrupt(SYSTICK_TIMER_NUM);
+  HAL_timer_start(SYSTICK_TIMER_NUM, SYSTICK_TIMER_FREQUENCY);
 }
 
 void HAL_timer_start(const uint8_t timer_num, const uint32_t frequency) {

--- a/Marlin/src/HAL/NATIVE_SIM/timers.h
+++ b/Marlin/src/HAL/NATIVE_SIM/timers.h
@@ -46,6 +46,10 @@ typedef uint64_t hal_timer_t;
 #ifndef TEMP_TIMER_NUM
   #define TEMP_TIMER_NUM        1  // Timer Index for Temperature
 #endif
+#ifndef SYSTICK_TIMER_NUM
+  #define SYSTICK_TIMER_NUM     2 // Timer Index for Systick
+#endif
+#define SYSTICK_TIMER_FREQUENCY 1000
 
 #define TEMP_TIMER_RATE        1000000
 #define TEMP_TIMER_FREQUENCY   1000 // temperature interrupt frequency

--- a/Marlin/src/HAL/NATIVE_SIM/u8g/u8g_com_sw_spi.cpp
+++ b/Marlin/src/HAL/NATIVE_SIM/u8g/u8g_com_sw_spi.cpp
@@ -208,7 +208,7 @@ uint8_t u8g_com_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_pt
   }
 #endif
 
-#else
+#elif !ANY(TFT_COLOR_UI, TFT_CLASSIC_UI, TFT_LVGL_UI)
   #include <U8glib.h>
   uint8_t u8g_com_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr) {return 0;}
 #endif // HAS_MARLINUI_U8GLIB && !U8GLIB_ST7920

--- a/Marlin/src/lcd/extui/lib/mks_ui/tft_lvgl_configuration.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/tft_lvgl_configuration.cpp
@@ -517,4 +517,11 @@ void lv_encoder_pin_init() {
 
 #endif // HAS_ENCODER_ACTION
 
+// we need to define it here
+#if __PLAT_NATIVE_SIM__
+  #include <lv_misc/lv_log.h>
+  typedef void (*lv_log_print_g_cb_t)(lv_log_level_t level, const char *, uint32_t, const char *);
+  extern "C" void lv_log_register_print_cb(lv_log_print_g_cb_t print_cb) {}
+#endif
+
 #endif // HAS_TFT_LVGL_UI

--- a/Marlin/src/pins/linux/pins_RAMPS_LINUX.h
+++ b/Marlin/src/pins/linux/pins_RAMPS_LINUX.h
@@ -393,7 +393,34 @@
 // LCDs and Controllers //
 //////////////////////////
 
-#if HAS_WIRED_LCD
+#if ANY(TFT_COLOR_UI, TFT_CLASSIC_UI, TFT_LVGL_UI)
+
+  #define TFT_A0_PIN            44
+  #define TFT_CS_PIN            49
+  #define TFT_DC_PIN            44
+  #define TFT_SCK_PIN           SCK_PIN
+  #define TFT_MOSI_PIN          MOSI_PIN
+
+  #define BTN_EN1                         40
+  #define BTN_EN2                         63
+  #define BTN_ENC                         59
+  #define BEEPER_PIN                      42
+
+  #define TOUCH_CS_PIN                    33
+
+  #define HAS_SPI_FLASH                    1
+  #if HAS_SPI_FLASH
+    #define SPI_DEVICE                     1
+    #define SPI_FLASH_SIZE         0x1000000  // 16MB
+    #define W25QXX_CS_PIN                 31
+    #define W25QXX_MOSI_PIN         MOSI_PIN
+    #define W25QXX_MISO_PIN         MISO_PIN
+    #define W25QXX_SCK_PIN           SCK_PIN
+  #endif
+
+  #define TFT_BUFFER_SIZE             0xFFFF
+
+#elif HAS_WIRED_LCD
 
   //
   // LCD Display output pins
@@ -604,19 +631,6 @@
     #elif ENABLED(AZSMZ_12864)
 
       // Pins only defined for RAMPS_SMART currently
-    #elif ENABLED(TFT_COLOR_UI)
-      #define TFT_A0_PIN            LCD_PINS_D6
-      #define TFT_CS_PIN            LCD_PINS_RS
-      #define TFT_DC_PIN            LCD_PINS_D6
-      #define TFT_SCK_PIN           SCK_PIN
-      #define TFT_MOSI_PIN          MOSI_PIN
-
-      #define BTN_EN1                         40
-      #define BTN_EN2                         63
-      #define BTN_ENC                         59
-      #define BEEPER_PIN                      42
-
-      #define TOUCH_CS_PIN                    33
 
     #else
 

--- a/Marlin/src/pins/linux/pins_RAMPS_LINUX.h
+++ b/Marlin/src/pins/linux/pins_RAMPS_LINUX.h
@@ -400,6 +400,7 @@
   #define TFT_DC_PIN            44
   #define TFT_SCK_PIN           SCK_PIN
   #define TFT_MOSI_PIN          MOSI_PIN
+  #define LCD_USE_DMA_SPI
 
   #define BTN_EN1                         40
   #define BTN_EN2                         63

--- a/Marlin/src/pins/linux/pins_RAMPS_LINUX.h
+++ b/Marlin/src/pins/linux/pins_RAMPS_LINUX.h
@@ -604,6 +604,19 @@
     #elif ENABLED(AZSMZ_12864)
 
       // Pins only defined for RAMPS_SMART currently
+    #elif ENABLED(TFT_COLOR_UI)
+      #define TFT_A0_PIN            LCD_PINS_D6
+      #define TFT_CS_PIN            LCD_PINS_RS
+      #define TFT_DC_PIN            LCD_PINS_D6
+      #define TFT_SCK_PIN           SCK_PIN
+      #define TFT_MOSI_PIN          MOSI_PIN
+
+      #define BTN_EN1                         40
+      #define BTN_EN2                         63
+      #define BTN_ENC                         59
+      #define BEEPER_PIN                      42
+
+      #define TOUCH_CS_PIN                    33
 
     #else
 

--- a/Marlin/src/sd/SdFatUtil.cpp
+++ b/Marlin/src/sd/SdFatUtil.cpp
@@ -48,6 +48,10 @@
     return &top - reinterpret_cast<char*>(sbrk(0));
   }
 
+#elif __PLAT_NATIVE_SIM__
+  int SdFatUtil::FreeRam() {
+    return 0xFFFFFFFF;
+  }
 #else
 
   extern char* __brkval;


### PR DESCRIPTION
### Description

This PR add support for a few spi devices:
 - [x] ST7796 TFT
 - [x] XPT2046 (touch)
 - [x] SD Card (spi)
 - [x] Support for SD writing
 - [x] SPI Slave Peripheral base class, to easily create new spi hw for the simulator
 - [x] HAL_spi.cpp with marlin spi functions for the simulator HAL
 - [x] TFT and touch support for simulator HAL (spi)
 - [X] Color UI support
 - [x] Classic UI support
 - [x] LVGL UI support
 - [x] SPIClass and MarlinSPI class to simulator HAL
 - [x] W25Qxx SPI Flash harware
 - [x] Integrate the devices with Application class

### Benefits

<!-- What does this fix or improve? -->

### Configurations

<!-- Attach any Configuration.h, Configuration_adv.h, or platformio.ini files needed to compile/test your Pull Request. -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
