### PR TITLE
Avoid accessing isr_stack when loaded libraries call delay during glob…

### DIFF
--- a/Marlin/src/HAL/NATIVE_SIM/sim/execution_control.h
+++ b/Marlin/src/HAL/NATIVE_SIM/sim/execution_control.h
@@ -214,6 +214,10 @@ public:
     static std::array<KernelTimer, 4> timers;
   };
 
+  // To avoid issues with global initialization order, this should be called with a true value
+  // to enable operation of execute_loop.
+  static bool is_initialized(bool known_state = false);
+
   //execute highest priority thread with closest interrupt, return true if something was executed
   static bool execute_loop(uint64_t max_end_ticks = std::numeric_limits<uint64_t>::max());
   // if a thread wants to wait, see what should be executed during that wait

--- a/Marlin/src/HAL/NATIVE_SIM/sim/main.cpp
+++ b/Marlin/src/HAL/NATIVE_SIM/sim/main.cpp
@@ -54,6 +54,7 @@ void simulation_main() {
   Kernel::Timers::timerInit(3, 1000000);
   Kernel::Timers::timerStart(3, 500);
   Kernel::Timers::timerEnable(3);
+  Kernel::is_initialized(true);
 
   while(!main_finished) {
     try {


### PR DESCRIPTION
### Description

The U8G library calls delay() on Windows before the kernel is initialized. This crashes the simulator, because isr_stack is not yet initialized.

Do not actually process delays or yields prior to the thread telling the kernel it is initialized.

### Benefits

Doesn't hang on launch on Windows

### Configurations

[Configuration_adv.zip](https://github.com/p3p/Marlin/files/5541955/Configuration_adv.zip)

### Related Issues

N/A
