### PR TITLE
Make sim probe optional

### DIFF
--- a/Marlin/src/HAL/NATIVE_SIM/sim/visualisation.cpp
+++ b/Marlin/src/HAL/NATIVE_SIM/sim/visualisation.cpp
@@ -27,8 +27,10 @@ Visualisation::Visualisation() :
   y_axis(Y_ENABLE_PIN, Y_DIR_PIN, Y_STEP_PIN, Y_MIN_PIN, Y_MAX_PIN, INVERT_Y_DIR),
   z_axis(Z_ENABLE_PIN, Z_DIR_PIN, Z_STEP_PIN, Z_MIN_PIN, Z_MAX_PIN, INVERT_Z_DIR),
   extruder0(E0_ENABLE_PIN, E0_DIR_PIN, E0_STEP_PIN, P_NC, P_NC, INVERT_E0_DIR),
-  print_bed({X_BED_SIZE, Y_BED_SIZE}),
-  probe(pin_type(Z_MIN_PROBE_PIN), NOZZLE_TO_PROBE_OFFSET, effector_pos, print_bed)
+  print_bed({X_BED_SIZE, Y_BED_SIZE})
+  #if HAS_BED_PROBE
+  , probe(pin_type(Z_MIN_PROBE_PIN), NOZZLE_TO_PROBE_OFFSET, effector_pos, print_bed)
+  #endif
   #if ENABLED(FILAMENT_RUNOUT_SENSOR)
   , runout_sensor(FIL_RUNOUT1_PIN, FIL_RUNOUT_STATE)
   #endif

--- a/Marlin/src/HAL/NATIVE_SIM/sim/visualisation.h
+++ b/Marlin/src/HAL/NATIVE_SIM/sim/visualisation.h
@@ -172,7 +172,9 @@ public:
   LinearAxis extruder0;
   PrintBed print_bed;
   glm::vec3 bed_level_point[3] = {{build_plate_dimension.x / 2, build_plate_dimension.y,0},{0,0,0},{build_plate_dimension.x,0,0}};
-  BedProbe probe;
+  #if HAS_BED_PROBE
+    BedProbe probe;
+  #endif
   #if ENABLED(FILAMENT_RUNOUT_SENSOR)
     FilamentRunoutSensor runout_sensor;
   #endif


### PR DESCRIPTION
### Description

This eliminates the need to have a probe in the simulator.

### Configurations

Sample config which depends on this:
[Configuration_adv.zip](https://github.com/p3p/Marlin/files/5634372/Configuration_adv.zip)
